### PR TITLE
Update exposecontroller image stream repo

### DIFF
--- a/deploy/exposecontroller.yaml
+++ b/deploy/exposecontroller.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       serviceAccountName: container-jfr-operator
       containers:
-      - image: fabric8/exposecontroller
+      - image: jenkinsxio/exposecontroller
         name: exposecontroller
         args:
           - --v=8


### PR DESCRIPTION
The image repository used in the initial commit series was out of date, so this one-liner corrects it.