### PR TITLE
Modify scorecard config for sdk v0.10.1 compatibility

### DIFF
--- a/.osdk-scorecard.yaml
+++ b/.osdk-scorecard.yaml
@@ -1,14 +1,3 @@
 ---
-scorecard:
-    output: text
-    namespace: scorecard
-    crds-dir: "deploy/crds"
-    plugins:
-        # TODO add test configurations for FlightRecorders
-        - basic:
-            cr-manifest:
-                - "deploy/crds/rhjmc_v1alpha1_containerjfr_cr.yaml"
-        - olm:
-            cr-manifest:
-                - "deploy/crds/rhjmc_v1alpha1_containerjfr_cr.yaml"
-            csv-path: "bundle/container-jfr-operator.v0.0.1.clusterserviceversion.yaml"
+csv-path: "bundle/container-jfr-operator.v0.0.1.clusterserviceversion.yaml"
+cr-manifest: "deploy/crds/rhjmc_v1alpha1_containerjfr_cr.yaml"

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ clean-bundle:
 
 
 #########################################
-# "Local" (ex. minishift/crc) testing targets #
+# "Local" (ex. crc) testing targets #
 #########################################
 
 .PHONY: deploy


### PR DESCRIPTION
The current config was written with an operator-sdk v0.11.0 client binary in use. This simpler config is compatible with the v0.10.x currently specified in the project go.mod.