### PR TITLE
[WIP] Connecting to command service to list recordings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/rh-jmc-team/container-jfr-operator
 
 require (
 	github.com/go-openapi/spec v0.17.2
+	github.com/gorilla/websocket v1.4.1
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/openshift/client-go v3.9.0+incompatible
 	github.com/operator-framework/operator-sdk v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,7 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/structtag v1.0.0/go.mod h1:IKitwq45uXL/yqi5mYghiD3w9H6eTOvI9vnk8tXMphA=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gernest/wow v0.1.0/go.mod h1:dEPabJRi5BneI1Nev1VWo0ZlcTWibHWp43qxKms4elY=
 github.com/getsentry/raven-go v0.1.2/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
@@ -169,6 +170,7 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20180924190550-6f2cf27854a4/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -186,6 +188,7 @@ github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8l
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -212,6 +215,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e/go.mod h1:wJfORR
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
+github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/gregjones/httpcache v0.0.0-20181110185634-c63ab54fda8f/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/gregjones/httpcache v0.0.0-20190203031600-7a902570cb17/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
@@ -252,6 +257,7 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/iancoleman/strcase v0.0.0-20180726023541-3605ed457bf7/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
@@ -286,9 +292,11 @@ github.com/konsorten/go-windows-terminal-sequences v0.0.0-20180402223658-b729f26
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/leanovate/gopter v0.2.4/go.mod h1:gNcbPWNEWRe4lm+bycKqxUYoH5uoVje5SkOJ3uoLer8=
@@ -345,10 +353,12 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.8.0 h1:VkHVNpR4iVnU8XQR6DBm8BqYjN7CRzw+xKUbVVbbW9w=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.2-0.20180831124310-ae19f1b56d53/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.2/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
@@ -387,6 +397,7 @@ github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -461,6 +472,7 @@ github.com/stevvooe/resumable v0.0.0-20180830230917-22b14a53ba50/go.mod h1:1pdIZ
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/technosophos/moniker v0.0.0-20180509230615-a5dbd03a2245/go.mod h1:O1c8HleITsZqzNZDjSNzirUGsMT0oGu9LhHKoJrqO+A=
@@ -603,6 +615,7 @@ google.golang.org/api v0.3.2/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMt
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
@@ -621,6 +634,7 @@ google.golang.org/grpc v1.19.1/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZi
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
@@ -635,6 +649,7 @@ gopkg.in/natefinch/lumberjack.v2 v2.0.0-20170531160350-a96e63847dc3/go.mod h1:l0
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.3.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/urfave/cli.v1 v1.20.0/go.mod h1:vuBzUtMdQeixQj8LVd+/98pzhxNGQoyuPBlsXHOQNO0=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
@@ -649,6 +664,7 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/api v0.0.0-20190409021203-6e4e0e4f393b h1:aBGgKJUM9Hk/3AE8WaZIApnTxG35kbuQba2w+SXqezo=
 k8s.io/api v0.0.0-20190409021203-6e4e0e4f393b/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
+k8s.io/apiextensions-apiserver v0.0.0-20190409022649-727a075fdec8 h1:q1Qvjzs/iEdXF6A1a8H3AKVFDzJNcJn3nXMs6R6qFtA=
 k8s.io/apiextensions-apiserver v0.0.0-20190409022649-727a075fdec8/go.mod h1:IxkesAMoaCRoLrPJdZNZUQp9NfZnzqaVzLhb2VEQzXE=
 k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d h1:Jmdtdt1ZnoGfWWIIik61Z7nKYgO3J+swQJtPYsP9wHA=
 k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
@@ -690,8 +706,10 @@ sigs.k8s.io/controller-runtime v0.1.10/go.mod h1:HFAYoOh6XMV+jKF1UjFwrknPbowfyHE
 sigs.k8s.io/controller-runtime v0.2.0/go.mod h1:ZHqrRDZi3f6BzONcvlUxkqCKgwasGk5FZrnSv9TVZF4=
 sigs.k8s.io/controller-runtime v0.2.2 h1:JT/vJJhUjjL9NZNwnm8AXmqCBUXSCFKmTaNjwDi28N0=
 sigs.k8s.io/controller-runtime v0.2.2/go.mod h1:9dyohw3ZtoXQuV1e766PHUn+cmrRCIcBh6XIMFNMZ+I=
+sigs.k8s.io/controller-tools v0.2.0 h1:AmQ/0JKBJAjyAiPAkrAf9QW06jkx2lc5hpxMjamsFpw=
 sigs.k8s.io/controller-tools v0.2.0/go.mod h1:8t/X+FVWvk6TaBcsa+UKUBbn7GMtvyBKX30SGl4em6Y=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
+sigs.k8s.io/testing_frameworks v0.1.1 h1:cP2l8fkA3O9vekpy5Ks8mmA0NW/F7yBdXf8brkWhVrs=
 sigs.k8s.io/testing_frameworks v0.1.1/go.mod h1:VVBKrHmJ6Ekkfz284YKhQePcdycOzNH9qL6ht1zEr/U=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/pkg/client/command_types.go
+++ b/pkg/client/command_types.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"encoding/json"
+)
+
+type CommandMessage struct {
+	Command string   `json:"command"`
+	Args    []string `json:"args"`
+}
+
+func NewCommandMessage(command string, args ...string) *CommandMessage {
+	return &CommandMessage{Command: command, Args: args}
+}
+
+type ResponseMessage struct {
+	CommandName string      `json:"commandName"`
+	Status      int         `json:"status"`
+	Payload     interface{} `json:"payload"`
+}
+
+type RecordingState string
+
+const (
+	RecordingStateCreated  RecordingState = "CREATED"
+	RecordingStateRunning  RecordingState = "RUNNING"
+	RecordingStateStopping RecordingState = "STOPPING"
+	RecordingStateStopped  RecordingState = "STOPPED"
+)
+
+type RecordingDescriptor struct {
+	ID         int64          `json:"id"`
+	Name       string         `json:"name"`
+	State      RecordingState `json:"state"`
+	StartTime  int64          `json:"startTime"`
+	Duration   int64          `json:"duration"`
+	Continuous bool           `json:"continuous"`
+	ToDisk     bool           `json:"toDisk"`
+	MaxSize    int64          `json:"maxSize"`
+	MaxAge     int64          `json:"maxAge"`
+}
+
+// UnmarshalJSON overrides standard JSON parsing to handle error payloads
+func (msg *ResponseMessage) UnmarshalJSON(data []byte) error {
+	// Unmarshall only status at first to determine if we need to
+	// parse an error string
+	peekStatus := struct {
+		Status int `json:"status"`
+	}{}
+	err := json.Unmarshal(data, &peekStatus)
+	if err != nil {
+		return err
+	}
+	if peekStatus.Status < 0 {
+		// Expect a string payload for non-zero status
+		msg.Payload = ""
+	}
+	// Use an alias to prevent infinite recursion on this method
+	type responseMessageAlias ResponseMessage
+	err = json.Unmarshal(data, (*responseMessageAlias)(msg))
+	return err
+}

--- a/pkg/client/containerjfr_client.go
+++ b/pkg/client/containerjfr_client.go
@@ -1,0 +1,92 @@
+package flightrecorder
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/url"
+	"time"
+
+	"github.com/gorilla/websocket"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var log = logf.Log.WithName("containerjfr_client")
+
+type ClientConfig struct {
+	ServerURL *url.URL
+}
+
+type ContainerJfrClient struct {
+	config *ClientConfig
+}
+
+type CommandMessage struct {
+	Command string   `json:"command"`
+	Args    []string `json:"args,omitempty"`
+}
+
+func Create(config *ClientConfig) *ContainerJfrClient {
+	return &ContainerJfrClient{config}
+}
+
+func (client *ContainerJfrClient) Connect() error {
+	urlStr := client.config.ServerURL.String()
+	conn, resp, err := websocket.DefaultDialer.Dial(urlStr, nil)
+	if err != nil {
+		log.Error(err, "failed to connect to command channel", "server", urlStr)
+		if resp != nil {
+			body, _ := ioutil.ReadAll(resp.Body)
+			log.Info("response", "status", resp.Status, "body", string(body))
+		}
+		return err
+	}
+	defer conn.Close()
+
+	done := make(chan struct{})
+	gotRead := make(chan struct{}) // XXX
+
+	go func() {
+		defer close(done)
+		for {
+			_, msg, err := conn.ReadMessage() // TODO consider ReadJSON
+			if err != nil {
+				if err != io.EOF {
+					log.Error(err, "could not read message")
+				}
+				return // TODO keep going?
+			}
+			log.Info("read message", "msg", string(msg))
+			close(gotRead)
+		}
+	}()
+
+	pingCmd := &CommandMessage{Command: "ping"}
+	jsonCmd, err := json.Marshal(pingCmd)
+	if err != nil {
+		return err
+	}
+	log.Info("sending command", "json", string(jsonCmd))
+
+	err = conn.WriteJSON(pingCmd)
+	if err != nil {
+		log.Error(err, "could not write message")
+	}
+
+	<-gotRead // XXX
+
+	err = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+	if err != nil {
+		log.Error(err, "failed to close connection with server")
+		return err
+	} // TODO how to graceful shutdown
+
+	select {
+	case <-done:
+		log.Info("closed connection with server")
+		return nil
+	case <-time.After(time.Second):
+		log.Info("timed out waiting to close connection with server")
+		return nil
+	}
+}

--- a/pkg/client/containerjfr_client.go
+++ b/pkg/client/containerjfr_client.go
@@ -2,7 +2,7 @@ package flightrecorder
 
 import (
 	"encoding/json"
-	"io"
+	"fmt"
 	"io/ioutil"
 	"net/url"
 	"time"
@@ -19,19 +19,32 @@ type ClientConfig struct {
 
 type ContainerJfrClient struct {
 	config *ClientConfig
+	conn   *websocket.Conn
 }
 
 type CommandMessage struct {
 	Command string   `json:"command"`
-	Args    []string `json:"args,omitempty"`
+	Args    []string `json:"args"`
 }
 
-func Create(config *ClientConfig) *ContainerJfrClient {
-	return &ContainerJfrClient{config}
+func Create(config *ClientConfig) (*ContainerJfrClient, error) {
+	conn, err := newWebSocketConn(config.ServerURL)
+	if err != nil {
+		return nil, err
+	}
+	client := &ContainerJfrClient{config: config, conn: conn}
+	return client, nil
 }
 
-func (client *ContainerJfrClient) Connect() error {
-	urlStr := client.config.ServerURL.String()
+func (client *ContainerJfrClient) Close() error {
+	return client.conn.Close()
+}
+
+Mesages can be out of order, maybe queue, and filter. Look at what container-jfr-web does
+
+func newWebSocketConn(server *url.URL) (*websocket.Conn, error) {
+	time.Sleep(time.Minute) // XXX
+	urlStr := server.String()
 	conn, resp, err := websocket.DefaultDialer.Dial(urlStr, nil)
 	if err != nil {
 		log.Error(err, "failed to connect to command channel", "server", urlStr)
@@ -39,54 +52,122 @@ func (client *ContainerJfrClient) Connect() error {
 			body, _ := ioutil.ReadAll(resp.Body)
 			log.Info("response", "status", resp.Status, "body", string(body))
 		}
-		return err
+		return nil, err
 	}
-	defer conn.Close()
-
-	done := make(chan struct{})
-	gotRead := make(chan struct{}) // XXX
-
-	go func() {
-		defer close(done)
-		for {
-			_, msg, err := conn.ReadMessage() // TODO consider ReadJSON
-			if err != nil {
-				if err != io.EOF {
-					log.Error(err, "could not read message")
-				}
-				return // TODO keep going?
-			}
-			log.Info("read message", "msg", string(msg))
-			close(gotRead)
+	/*conn.SetCloseHandler(func(code int, text string) error {
+		// Attempt to reconnect
+		log.Info("attempting to reconnect to server", "server", urlStr)
+		conn.Close()
+		err = client.newWebSocketConn(server)
+		if err != nil {
+			log.Error(err, "failed to reconnect to server")
+			return err
 		}
-	}()
+		return nil
+	}) */
+	return conn, nil
+}
 
-	pingCmd := &CommandMessage{Command: "ping"}
-	jsonCmd, err := json.Marshal(pingCmd)
+func (client *ContainerJfrClient) connect(host string, port int) error {
+	target := fmt.Sprintf("%s:%d", host, port)
+	connectCmd := &CommandMessage{Command: "connect", Args: []string{target}}
+	jsonCmd, err := json.Marshal(connectCmd)
 	if err != nil {
 		return err
 	}
 	log.Info("sending command", "json", string(jsonCmd))
 
-	err = conn.WriteJSON(pingCmd)
+	err = client.conn.WriteJSON(connectCmd)
 	if err != nil {
-		log.Error(err, "could not write message")
-	}
-
-	<-gotRead // XXX
-
-	err = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
-	if err != nil {
-		log.Error(err, "failed to close connection with server")
+		log.Error(err, "could not write connect message")
 		return err
-	} // TODO how to graceful shutdown
-
-	select {
-	case <-done:
-		log.Info("closed connection with server")
-		return nil
-	case <-time.After(time.Second):
-		log.Info("timed out waiting to close connection with server")
-		return nil
 	}
+
+	_, msg, err := client.conn.ReadMessage()
+	if err != nil {
+		log.Error(err, "could not read connect message")
+		return err
+	}
+	log.Info(string(msg))
+	return nil
+}
+
+func (client *ContainerJfrClient) isConnected() error {
+	isConnectedCmd := &CommandMessage{Command: "is-connected", Args: []string{}}
+	jsonCmd, err := json.Marshal(isConnectedCmd)
+	if err != nil {
+		return err
+	}
+	log.Info("sending command", "json", string(jsonCmd))
+
+	err = client.conn.WriteJSON(isConnectedCmd)
+	if err != nil {
+		log.Error(err, "could not write is-connected message")
+		return err
+	}
+
+	_, msg, err := client.conn.ReadMessage()
+	if err != nil {
+		log.Error(err, "could not read is-connected message")
+		return err
+	}
+	log.Info(string(msg))
+	return nil
+}
+
+func (client *ContainerJfrClient) disconnect() error {
+	disconnectCmd := &CommandMessage{Command: "disconnect", Args: []string{}}
+	jsonCmd, err := json.Marshal(disconnectCmd)
+	if err != nil {
+		return err
+	}
+	log.Info("sending command", "json", string(jsonCmd))
+
+	err = client.conn.WriteJSON(disconnectCmd)
+	if err != nil {
+		log.Error(err, "could not write disconnect message")
+		return err
+	}
+
+	_, msg, err := client.conn.ReadMessage()
+	if err != nil {
+		log.Error(err, "could not read disconnect message")
+		return err
+	}
+	log.Info(string(msg))
+	return nil
+}
+
+func (client *ContainerJfrClient) ListRecordings(host string, port int) error {
+	err := client.isConnected()
+	if err != nil {
+		return err
+	}
+
+	err = client.connect(host, port)
+	if err != nil {
+		return err
+	}
+	defer client.disconnect()
+
+	listCmd := &CommandMessage{Command: "list", Args: []string{}}
+	jsonCmd, err := json.Marshal(listCmd)
+	if err != nil {
+		return err
+	}
+	log.Info("sending command", "json", string(jsonCmd))
+
+	err = client.conn.WriteJSON(listCmd)
+	if err != nil {
+		log.Error(err, "could not write list message")
+		return err
+	}
+
+	_, msg, err := client.conn.ReadMessage()
+	if err != nil {
+		log.Error(err, "could not read list message")
+		return err
+	}
+	log.Info(string(msg))
+	return nil
 }

--- a/pkg/controller/flightrecorder/flightrecorder_controller.go
+++ b/pkg/controller/flightrecorder/flightrecorder_controller.go
@@ -113,6 +113,8 @@ func (r *ReconcileFlightRecorder) Reconcile(request reconcile.Request) (reconcil
 	if err != nil {
 		return reconcile.Result{}, err // TODO should we requeue?
 	}
+	log.Info("Listing recordings for service", "service", targetSvc.Name, "namespace", targetSvc.Namespace,
+		"host", *clusterIP, "port", 9091)
 	err = r.jfrClient.ListRecordings(*clusterIP, 9091) // FIXME hardcoded port
 	if err != nil {
 		log.Error(err, "failed to connect to command server")

--- a/pkg/controller/flightrecorder/flightrecorder_controller.go
+++ b/pkg/controller/flightrecorder/flightrecorder_controller.go
@@ -2,12 +2,13 @@ package flightrecorder
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 
 	rhjmcv1alpha1 "github.com/rh-jmc-team/container-jfr-operator/pkg/apis/rhjmc/v1alpha1"
 	jfrclient "github.com/rh-jmc-team/container-jfr-operator/pkg/client"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,8 +62,9 @@ var _ reconcile.Reconciler = &ReconcileFlightRecorder{}
 type ReconcileFlightRecorder struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	client client.Client
-	scheme *runtime.Scheme
+	client    client.Client
+	scheme    *runtime.Scheme
+	jfrClient *jfrclient.ContainerJfrClient
 }
 
 // Reconcile reads that state of the cluster for a FlightRecorder object and makes changes based on the state read
@@ -77,32 +79,20 @@ func (r *ReconcileFlightRecorder) Reconcile(request reconcile.Request) (reconcil
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling FlightRecorder")
 
-	commandSvc := &corev1.Service{}
-	commandSvcName := "containerjfr-command"                                                                       // TODO make const or get from ContainerJFR
-	err := r.client.Get(ctx, types.NamespacedName{Namespace: request.Namespace, Name: commandSvcName}, commandSvc) // TODO what if it's a different namespace
-	if err != nil {
-		// Need service in order to reconcile anything, requeue until it appears
-		return reconcile.Result{}, err
-	}
-
-	clusterIP := commandSvc.Spec.ClusterIP
-	if clusterIP == "" || clusterIP == corev1.ClusterIPNone {
-		// TODO log error
-	}
-	commandURL := &url.URL{Scheme: "ws", Host: clusterIP + ":9090" /* FIXME make nicer */, Path: "command"}
-	config := &jfrclient.ClientConfig{ServerURL: commandURL}
-	jfrClient := jfrclient.Create(config)
-	err = jfrClient.Connect()
-	if err != nil {
-		log.Error(err, "failed to connect to command server")
-		return reconcile.Result{}, err
+	if r.jfrClient == nil {
+		jfrClient, err := r.connectToContainerJFR(ctx, request.Namespace)
+		if err != nil {
+			// Need service in order to reconcile anything, requeue until it appears
+			return reconcile.Result{}, err
+		}
+		r.jfrClient = jfrClient
 	}
 
 	// Fetch the FlightRecorder instance
 	instance := &rhjmcv1alpha1.FlightRecorder{}
-	err = r.client.Get(ctx, request.NamespacedName, instance)
+	err := r.client.Get(ctx, request.NamespacedName, instance)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if kerrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
@@ -112,6 +102,55 @@ func (r *ReconcileFlightRecorder) Reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, err
 	}
 
+	targetRef := instance.Status.Target
+	targetSvc := &corev1.Service{}
+	err = r.client.Get(ctx, types.NamespacedName{Namespace: targetRef.Namespace, Name: targetRef.Name}, targetSvc)
+	if err != nil {
+		return reconcile.Result{}, err // TODO should we requeue?
+	}
+
+	clusterIP, err := getClusterIP(targetSvc)
+	if err != nil {
+		return reconcile.Result{}, err // TODO should we requeue?
+	}
+	err = r.jfrClient.ListRecordings(*clusterIP, 9091) // FIXME hardcoded port
+	if err != nil {
+		log.Error(err, "failed to connect to command server")
+		r.jfrClient.Close()
+		r.jfrClient = nil
+		return reconcile.Result{}, err
+	}
+
 	reqLogger.Info("Found FlightRecorder", "Namespace", instance.Namespace, "Name", instance.Name)
 	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileFlightRecorder) connectToContainerJFR(ctx context.Context, namespace string) (*jfrclient.ContainerJfrClient, error) {
+	commandSvc := &corev1.Service{}
+	commandSvcName := "containerjfr-command"                                                               // TODO make const or get from ContainerJFR
+	err := r.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: commandSvcName}, commandSvc) // TODO what if it's a different namespace
+	if err != nil {
+		return nil, err
+	}
+
+	clusterIP, err := getClusterIP(commandSvc)
+	if err != nil {
+		return nil, err
+	}
+	host := fmt.Sprintf("%s:%d", *clusterIP, 9090) // FIXME hardcoded port
+	commandURL := &url.URL{Scheme: "ws", Host: host, Path: "command"}
+	config := &jfrclient.ClientConfig{ServerURL: commandURL}
+	jfrClient, err := jfrclient.Create(config)
+	if err != nil {
+		return nil, err
+	}
+	return jfrClient, nil
+}
+
+func getClusterIP(svc *corev1.Service) (*string, error) {
+	clusterIP := svc.Spec.ClusterIP
+	if clusterIP == "" || clusterIP == corev1.ClusterIPNone {
+		return nil, fmt.Errorf("ClusterIP unavailable for %s", svc.Name)
+	}
+	return &clusterIP, nil
 }

--- a/pkg/controller/flightrecorder/flightrecorder_controller.go
+++ b/pkg/controller/flightrecorder/flightrecorder_controller.go
@@ -14,9 +14,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
@@ -129,8 +129,9 @@ func (r *ReconcileFlightRecorder) Reconcile(request reconcile.Request) (reconcil
 
 func (r *ReconcileFlightRecorder) connectToContainerJFR(ctx context.Context, namespace string) (*jfrclient.ContainerJfrClient, error) {
 	commandSvc := &corev1.Service{}
-	commandSvcName := "containerjfr-command"                                                               // TODO make const or get from ContainerJFR
-	err := r.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: commandSvcName}, commandSvc) // TODO what if it's a different namespace
+	// TODO Get service namespace/name from ContainerJFR CR
+	commandSvcName := "containerjfr-command"
+	err := r.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: commandSvcName}, commandSvc)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR is the first attempt at filling in FlightRecorder custom resources with data received from Container JFR. I started with getting a listing of in-memory flight recordings for a JVM. The FlightRecorder reconciler will create a new WebSocket client (if it does not yet exist) and connect to Container JFR's command service. The WebSocket client should then:
1. Query if Container JFR is connected to a JVM already, and disconnect if so.
2. Connect to the JVM pointed to by the reconciler's enqueued FlightRecorder object.
3. Obtain a list of in-memory flight recordings and parse them into RecordingDescriptor structs.
4. Disconnect from the target JVM.

I'm encountering difficulty in step 2 when we try to connect to the target JVM. This seems to run fine for me when testing with a local Container JFR, but when running in OpenShift, I get repeated `close 1000 (normal)` control messages upon reading. Perhaps something is timing out here, because it takes a while to attempt to connect. Eventually, I seem to get a response for the inital connect request that has an exception like this: `WrappedConnectionException: Failed to retrieve RMIServer stub: javax.naming.ServiceUnavailableException [Root exception is java.rmi.ConnectException: Connection refused to host: 172.30.30.231; nested exception is: \n\tjava.net.ConnectException: Connection timed out (Connection timed out)]`. I checked to make sure the IP address and port correspond to the running Container JFR's service that exposes port 9091 for JMX.

I've attached the relevant logs for runs of the operator and Container JFR. Any help getting to the bottom of this issue would be much appreciated, I've been stumped for some time.

[container-jfr-log.txt](https://github.com/rh-jmc-team/container-jfr-operator/files/3806647/TMP-new-container-jfr-log.txt)
[operator-log.txt](https://github.com/rh-jmc-team/container-jfr-operator/files/3806648/TMP-new-operator-log.txt)

