### PR TITLE
Add "Minimal" field to ContainerJFR spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE_TAG ?= quay.io/rh-jmc-team/container-jfr-operator:0.1.7
+IMAGE_TAG ?= quay.io/rh-jmc-team/container-jfr-operator:0.1.8
 CRDS := containerjfr flightrecorder
 
 .DEFAULT_GOAL := bundle

--- a/bundle/container-jfr-operator-bundle.package.yaml
+++ b/bundle/container-jfr-operator-bundle.package.yaml
@@ -1,4 +1,4 @@
 packageName: container-jfr-operator-bundle
 channels:
   - name: alpha
-    currentCSV: container-jfr-operator-bundle.v0.0.7
+    currentCSV: container-jfr-operator-bundle.v0.0.8

--- a/bundle/container-jfr-operator.v0.0.7.clusterserviceversion.yaml
+++ b/bundle/container-jfr-operator.v0.0.7.clusterserviceversion.yaml
@@ -12,7 +12,9 @@ metadata:
           "metadata":{
             "name":"containerjfr"
           },
-          "spec":{}
+          "spec":{
+              "minimal":false
+          }
         },
         {
           "apiVersion":"apiextensions.k8s.io/v1beta1",

--- a/bundle/container-jfr-operator.v0.0.8.clusterserviceversion.yaml
+++ b/bundle/container-jfr-operator.v0.0.8.clusterserviceversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: container-jfr-operator-bundle.v0.0.7
+  name: container-jfr-operator-bundle.v0.0.8
   namespace: placeholder
   annotations:
     alm-examples: >-
@@ -32,7 +32,7 @@ metadata:
     createdAt: 2019-11-04T00:00:00Z
     description: JVM monitoring and profiling tool
     # TODO automatically replace the version tag
-    containerImage: quay.io/rh-jmc-team/container-jfr-operator:0.1.7
+    containerImage: quay.io/rh-jmc-team/container-jfr-operator:0.1.8
     support: Red Hat
     capabilities: Basic Install
     repository: github.com/rh-jmc-team/container-jfr-operator
@@ -47,7 +47,7 @@ spec:
     applications and analyze recording data without transferring data outside
     of the cluster the application runs within.
   maturity: pre-alpha
-  version: 0.0.7
+  version: 0.0.8
   replaces: ''
   minKubeVersion: ''
   keywords:
@@ -204,7 +204,7 @@ spec:
                 serviceAccountName: container-jfr-operator
                 containers:
                   - name: container-jfr-operator
-                    image: 'quay.io/rh-jmc-team/container-jfr-operator:0.1.7'
+                    image: 'quay.io/rh-jmc-team/container-jfr-operator:0.1.8'
                     command:
                       - container-jfr-operator
                     imagePullPolicy: Always

--- a/deploy/crds/rhjmc.redhat.com_containerjfrs_crd.yaml
+++ b/deploy/crds/rhjmc.redhat.com_containerjfrs_crd.yaml
@@ -30,6 +30,11 @@ spec:
           type: object
         spec:
           description: ContainerJFRSpec defines the desired state of ContainerJFR
+          properties:
+            minimal:
+              type: boolean
+          required:
+          - minimal
           type: object
         status:
           description: ContainerJFRStatus defines the observed state of ContainerJFR

--- a/deploy/crds/rhjmc.redhat.com_v1alpha1_containerjfr_cr.yaml
+++ b/deploy/crds/rhjmc.redhat.com_v1alpha1_containerjfr_cr.yaml
@@ -3,5 +3,4 @@ kind: ContainerJFR
 metadata:
   name: containerjfr
 spec:
-  # Add fields here
-  size: 1
+  minimal: false

--- a/pkg/apis/rhjmc/v1alpha1/containerjfr_types.go
+++ b/pkg/apis/rhjmc/v1alpha1/containerjfr_types.go
@@ -10,9 +10,7 @@ import (
 // ContainerJFRSpec defines the desired state of ContainerJFR
 // +k8s:openapi-gen=true
 type ContainerJFRSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
+	Minimal bool `json:"minimal"`
 }
 
 // ContainerJFRStatus defines the observed state of ContainerJFR

--- a/pkg/apis/rhjmc/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/rhjmc/v1alpha1/zz_generated.openapi.go
@@ -70,6 +70,15 @@ func schema_pkg_apis_rhjmc_v1alpha1_ContainerJFRSpec(ref common.ReferenceCallbac
 			SchemaProps: spec.SchemaProps{
 				Description: "ContainerJFRSpec defines the desired state of ContainerJFR",
 				Type:        []string{"object"},
+				Properties: map[string]spec.Schema{
+					"minimal": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+				},
+				Required: []string{"minimal"},
 			},
 		},
 	}


### PR DESCRIPTION
If "Minimal" is set to true then container-jfr will be deployed with the
-minimal image variant, containing no web-client UI resources, and the
pod deployment will also not contain Grafana or jfr-datasource containers, services, or routes.

The Operator also creates/cleans up the additional services and routes if the Spec.Minimal field changes on an existing ContainerJFR. The Pod will be destroyed and recreated to match - it should be checked in the future that this can't be done more efficiently and less disruptively by updating the set of containers running within the Pod.

Fixes #27