### PR TITLE
Tls edge

### DIFF
--- a/pkg/controller/containerjfr/containerjfr_controller.go
+++ b/pkg/controller/containerjfr/containerjfr_controller.go
@@ -116,7 +116,7 @@ func (r *ReconcileContainerJFR) Reconcile(request reconcile.Request) (reconcile.
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-		serviceSpecs.GrafanaAddress = fmt.Sprintf("http://%s", url)
+		serviceSpecs.GrafanaAddress = fmt.Sprintf("https://%s", url)
 
 		datasourceSvc := resources.NewJfrDatasourceService(instance)
 		url, err = r.createService(context.Background(), instance, datasourceSvc, datasourceSvc.Spec.Ports[0])
@@ -224,6 +224,10 @@ func (r *ReconcileContainerJFR) createRouteForService(controller *rhjmcv1alpha1.
 				Name: svc.Name,
 			},
 			Port: &openshiftv1.RoutePort{TargetPort: exposePort.TargetPort},
+			TLS: &openshiftv1.TLSConfig{
+				Termination:                   openshiftv1.TLSTerminationEdge,
+				InsecureEdgeTerminationPolicy: openshiftv1.InsecureEdgeTerminationPolicyRedirect,
+			},
 		},
 	}
 	if err := controllerutil.SetControllerReference(controller, route, r.scheme); err != nil {

--- a/pkg/controller/containerjfr/containerjfr_controller.go
+++ b/pkg/controller/containerjfr/containerjfr_controller.go
@@ -222,7 +222,7 @@ func (r *ReconcileContainerJFR) createService(ctx context.Context, controller *r
 	if len(svc.Spec.Ports) != 1 {
 		return "", errors.NewInternalError(goerrors.New(fmt.Sprintf("Expected service %s to have one Port, but got %d", svc.Name, len(svc.Spec.Ports))))
 	}
-	return fmt.Sprintf("%s:%d", svc.Spec.ClusterIP, svc.Spec.Ports[0].TargetPort.IntVal), nil
+	return fmt.Sprintf("%s:%d", svc.Spec.ClusterIP, svc.Spec.Ports[0].Port), nil
 }
 
 func (r *ReconcileContainerJFR) createRouteForService(controller *rhjmcv1alpha1.ContainerJFR, svc *corev1.Service, exposePort corev1.ServicePort) (string, error) {

--- a/pkg/controller/containerjfr/containerjfr_controller.go
+++ b/pkg/controller/containerjfr/containerjfr_controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	goerrors "errors"
 	openshiftv1 "github.com/openshift/api/route/v1"
 	routeClient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	rhjmcv1alpha1 "github.com/rh-jmc-team/container-jfr-operator/pkg/apis/rhjmc/v1alpha1"
@@ -112,14 +113,14 @@ func (r *ReconcileContainerJFR) Reconcile(request reconcile.Request) (reconcile.
 	var url string
 	if !instance.Spec.Minimal {
 		grafanaSvc := resources.NewGrafanaService(instance)
-		url, err = r.createService(context.Background(), instance, grafanaSvc, grafanaSvc.Spec.Ports[0])
+		url, err = r.createService(context.Background(), instance, grafanaSvc, &grafanaSvc.Spec.Ports[0])
 		if err != nil {
 			return reconcile.Result{}, err
 		}
 		serviceSpecs.GrafanaAddress = fmt.Sprintf("https://%s", url)
 
 		datasourceSvc := resources.NewJfrDatasourceService(instance)
-		url, err = r.createService(context.Background(), instance, datasourceSvc, datasourceSvc.Spec.Ports[0])
+		url, err = r.createService(context.Background(), instance, datasourceSvc, nil)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
@@ -174,14 +175,14 @@ func (r *ReconcileContainerJFR) Reconcile(request reconcile.Request) (reconcile.
 	}
 
 	exporterSvc := resources.NewExporterService(instance)
-	url, err = r.createService(context.Background(), instance, exporterSvc, exporterSvc.Spec.Ports[0])
+	url, err = r.createService(context.Background(), instance, exporterSvc, &exporterSvc.Spec.Ports[0])
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 	serviceSpecs.CoreAddress = url
 
 	cmdChanSvc := resources.NewCommandChannelService(instance)
-	url, err = r.createService(context.Background(), instance, cmdChanSvc, cmdChanSvc.Spec.Ports[0])
+	url, err = r.createService(context.Background(), instance, cmdChanSvc, &cmdChanSvc.Spec.Ports[0])
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -200,7 +201,7 @@ func (r *ReconcileContainerJFR) Reconcile(request reconcile.Request) (reconcile.
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileContainerJFR) createService(ctx context.Context, controller *rhjmcv1alpha1.ContainerJFR, svc *corev1.Service, exposePort corev1.ServicePort) (string, error) {
+func (r *ReconcileContainerJFR) createService(ctx context.Context, controller *rhjmcv1alpha1.ContainerJFR, svc *corev1.Service, exposePort *corev1.ServicePort) (string, error) {
 	if err := controllerutil.SetControllerReference(controller, svc, r.scheme); err != nil {
 		return "", err
 	}
@@ -208,7 +209,20 @@ func (r *ReconcileContainerJFR) createService(ctx context.Context, controller *r
 		return "", err
 	}
 
-	return r.createRouteForService(controller, svc, exposePort)
+	if exposePort != nil {
+		return r.createRouteForService(controller, svc, *exposePort)
+	}
+
+	if err := r.client.Get(context.Background(), types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}, svc); err != nil {
+		return "", err
+	}
+	if svc.Spec.ClusterIP == "" {
+		return "", errors.NewInternalError(goerrors.New(fmt.Sprintf("Expected service %s to have ClusterIP, but got empty string", svc.Name)))
+	}
+	if len(svc.Spec.Ports) != 1 {
+		return "", errors.NewInternalError(goerrors.New(fmt.Sprintf("Expected service %s to have one Port, but got %d", svc.Name, len(svc.Spec.Ports))))
+	}
+	return fmt.Sprintf("%s:%d", svc.Spec.ClusterIP, svc.Spec.Ports[0].TargetPort.IntVal), nil
 }
 
 func (r *ReconcileContainerJFR) createRouteForService(controller *rhjmcv1alpha1.ContainerJFR, svc *corev1.Service, exposePort corev1.ServicePort) (string, error) {

--- a/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
+++ b/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
@@ -82,12 +82,20 @@ func NewPodForCR(cr *rhjmcv1alpha1.ContainerJFR, specs *ServiceSpecs) *corev1.Po
 func NewCoreContainer(cr *rhjmcv1alpha1.ContainerJFR, specs *ServiceSpecs) corev1.Container {
 	envs := []corev1.EnvVar{
 		{
+			Name:  "CONTAINER_JFR_SSL_PROXIED",
+			Value: "true",
+		},
+		{
+			Name:  "CONTAINER_JFR_ALLOW_UNTRUSTED_SSL",
+			Value: "true",
+		},
+		{
 			Name:  "CONTAINER_JFR_WEB_PORT",
 			Value: "8181",
 		},
 		{
 			Name:  "CONTAINER_JFR_EXT_WEB_PORT",
-			Value: "80",
+			Value: "443",
 		},
 		{
 			Name:  "CONTAINER_JFR_WEB_HOST",
@@ -99,7 +107,7 @@ func NewCoreContainer(cr *rhjmcv1alpha1.ContainerJFR, specs *ServiceSpecs) corev
 		},
 		{
 			Name:  "CONTAINER_JFR_EXT_LISTEN_PORT",
-			Value: "80",
+			Value: "443",
 		},
 		{
 			Name:  "CONTAINER_JFR_LISTEN_HOST",

--- a/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
+++ b/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
@@ -279,7 +279,7 @@ func NewJfrDatasourceService(cr *rhjmcv1alpha1.ContainerJFR) *corev1.Service {
 			},
 		},
 		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeLoadBalancer,
+			Type: corev1.ServiceTypeClusterIP,
 			Selector: map[string]string{
 				"app": cr.Name,
 			},

--- a/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
+++ b/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
@@ -114,7 +114,7 @@ func NewCoreContainer(cr *rhjmcv1alpha1.ContainerJFR, specs *ServiceSpecs) corev
 			Value: specs.DatasourceAddress,
 		},
 	}
-	imageTag := "quay.io/rh-jmc-team/container-jfr:0.7.0"
+	imageTag := "quay.io/rh-jmc-team/container-jfr:0.8.0"
 	if cr.Spec.Minimal {
 		imageTag += "-minimal"
 		envs = append(envs, corev1.EnvVar{

--- a/pkg/controller/grafana/grafana_controller.go
+++ b/pkg/controller/grafana/grafana_controller.go
@@ -189,7 +189,7 @@ func (r *ReconcileGrafana) configureGrafanaDatasource(route *openshiftv1.Route) 
 	if len(services.Items[0].Spec.Ports) != 1 {
 		return errors.NewInternalError(goerrors.New(fmt.Sprintf("Expected service %s to have one Port, but got %d", services.Items[0].Name, len(services.Items[0].Spec.Ports))))
 	}
-	datasourceUrl := fmt.Sprintf("http://%s:%d", services.Items[0].Spec.ClusterIP, services.Items[0].Spec.Ports[0].TargetPort.IntVal)
+	datasourceUrl := fmt.Sprintf("http://%s:%d", services.Items[0].Spec.ClusterIP, services.Items[0].Spec.Ports[0].Port)
 
 	datasource := GrafanaDatasource{
 		Name:      "jfr-datasource",


### PR DESCRIPTION
Addresses #39 . Enables TLS edge termination for container-jfr, command channel, and Grafana routes, and removes the external routing to the jfr-datasource service (so that it is inaccessible from the outside, which is more suitable anyway but also has the side effect of reducing the need for encrypted connections)