### PR TITLE
Topology view

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,14 @@ clean-bundle:
 # "Local" (ex. minishift/crc) testing targets #
 #########################################
 
+.PHONY: catalog
+catalog: remove_catalog
+	oc create -f bundle/openshift/operator-source.yaml
+
+.PHONY: remove_catalog
+remove_catalog:
+	- oc delete -f bundle/openshift/operator-source.yaml
+
 .PHONY: deploy
 deploy: undeploy
 	oc create -f deploy/service_account.yaml
@@ -73,6 +81,7 @@ undeploy: undeploy_sample_app
 	- oc delete serviceaccount container-jfr-operator
 	- oc delete crd flightrecorders.rhjmc.redhat.com
 	- oc delete crd containerjfrs.rhjmc.redhat.com
+	- oc delete -f bundle/openshift/operator-source.yaml
 
 .PHONY: sample_app
 sample_app:

--- a/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
+++ b/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
@@ -44,11 +44,13 @@ func NewDeploymentForCR(cr *rhjmcv1alpha1.ContainerJFR, specs *ServiceSpecs) *ap
 			Name:      cr.Name,
 			Namespace: cr.Namespace,
 			Labels: map[string]string{
-				"app":  cr.Name,
-				"kind": "containerjfr",
+				"app":                    cr.Name,
+				"kind":                   "containerjfr",
+				"app.kubernetes.io/name": "container-jfr",
 			},
 			Annotations: map[string]string{
-				"redhat.com/containerJfrUrl": specs.CoreAddress,
+				"redhat.com/containerJfrUrl":   specs.CoreAddress,
+				"app.openshift.io/connects-to": "container-jfr-operator",
 			},
 		},
 		Spec: appsv1.DeploymentSpec{


### PR DESCRIPTION
See #25

![Screenshot_2019-12-09 Topology · Red Hat OpenShift Container Platform](https://user-images.githubusercontent.com/3787464/70470443-ee2b1580-1ac2-11ea-8a65-b8b1c80b251a.png)

With this PR, the container-jfr Pod is placed into a Deployment, which allows it to be visible on the Topology view for developer accounts. Labels/annotations are also added to this Pod, which provide the arrow linking the container-jfr instance back up to its Operator parent. I spent some time trying to get the application grouping working, but this requires a corresponding label to be present on the Operator Deployment, which it does not seem is currently possible (https://godoc.org/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install contains no information about attaching labels or other metadata to the Deployment itself, only to its owned Pods). I did some manual testing and everything seems to still deploy and run correctly, both with the Makefile and via OperatorHub (with custom source). Scorecard testing is also unimpacted.