### PR TITLE
Auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,8 @@ undeploy: undeploy_sample_app
 
 .PHONY: sample_app
 sample_app:
-	oc new-app andrewazores/container-jmx-docker-listener:latest --name=jmx-listener
+	oc new-app quay.io/andrewazores/vertx-fib-demo
 
 .PHONY: undeploy_sample_app
 undeploy_sample_app:
-	- oc delete all -l app=jmx-listener
+	- oc delete all -l app=vertx-fib-demo

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ deploy: undeploy
 	oc create -f deploy/crds/rhjmc.redhat.com_flightrecorders_crd.yaml
 	oc create -f deploy/crds/rhjmc.redhat.com_containerjfrs_crd.yaml
 	sed -e 's|REPLACE_IMAGE|$(IMAGE_TAG)|g' deploy/dev_operator.yaml | oc create -f -
+	oc set env deployment/container-jfr-operator TLS_VERIFY=false
 	oc create -f deploy/crds/rhjmc.redhat.com_v1alpha1_containerjfr_cr.yaml
 
 .PHONY: undeploy

--- a/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
+++ b/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
@@ -150,7 +150,7 @@ func NewCoreContainer(cr *rhjmcv1alpha1.ContainerJFR, specs *ServiceSpecs) corev
 			Value: specs.DatasourceAddress,
 		},
 	}
-	imageTag := "quay.io/rh-jmc-team/container-jfr:0.9.0"
+	imageTag := "quay.io/rh-jmc-team/container-jfr:0.11.0"
 	if cr.Spec.Minimal {
 		imageTag += "-minimal"
 		envs = append(envs, corev1.EnvVar{

--- a/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
+++ b/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
@@ -150,7 +150,7 @@ func NewCoreContainer(cr *rhjmcv1alpha1.ContainerJFR, specs *ServiceSpecs) corev
 			Value: specs.DatasourceAddress,
 		},
 	}
-	imageTag := "quay.io/rh-jmc-team/container-jfr:0.8.0"
+	imageTag := "quay.io/rh-jmc-team/container-jfr:0.9.0"
 	if cr.Spec.Minimal {
 		imageTag += "-minimal"
 		envs = append(envs, corev1.EnvVar{

--- a/pkg/controller/flightrecorder/flightrecorder_controller.go
+++ b/pkg/controller/flightrecorder/flightrecorder_controller.go
@@ -7,6 +7,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
+	"strings"
 	"time"
 
 	rhjmcv1alpha1 "github.com/rh-jmc-team/container-jfr-operator/pkg/apis/rhjmc/v1alpha1"
@@ -249,8 +251,7 @@ func (r *ReconcileFlightRecorder) connectToContainerJFR(ctx context.Context, nam
 		return nil, err
 	}
 	strTok := string(tok)
-	// TODO set TLSVerify according to some externally configurable source (env var? CR?)
-	config := &jfrclient.Config{ServerURL: clientURL, AccessToken: &strTok, TLSVerify: false}
+	config := &jfrclient.Config{ServerURL: clientURL, AccessToken: &strTok, TLSVerify: !strings.EqualFold(os.Getenv("TLS_VERIFY"), "false")}
 	jfrClient, err := jfrclient.Create(config)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/flightrecorder/flightrecorder_controller.go
+++ b/pkg/controller/flightrecorder/flightrecorder_controller.go
@@ -244,7 +244,13 @@ func (r *ReconcileFlightRecorder) connectToContainerJFR(ctx context.Context, nam
 	if err != nil {
 		return nil, err
 	}
-	config := &jfrclient.Config{ServerURL: clientURL}
+	tok, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	if err != nil {
+		return nil, err
+	}
+	strTok := string(tok)
+	// TODO set TLSVerify according to some externally configurable source (env var? CR?)
+	config := &jfrclient.Config{ServerURL: clientURL, AccessToken: &strTok, TLSVerify: false}
 	jfrClient, err := jfrclient.Create(config)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/grafana/grafana_controller.go
+++ b/pkg/controller/grafana/grafana_controller.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	openshiftv1 "github.com/openshift/api/route/v1"
@@ -44,8 +46,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 			IdleConnTimeout:       defaultTransport.IdleConnTimeout,
 			ExpectContinueTimeout: defaultTransport.ExpectContinueTimeout,
 			TLSHandshakeTimeout:   defaultTransport.TLSHandshakeTimeout,
-			// TODO for CRC development only. Make this configurable and only set in a -dev image
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig:       &tls.Config{InsecureSkipVerify: strings.EqualFold(os.Getenv("TLS_VERIFY"), "false")},
 		},
 	}
 


### PR DESCRIPTION
This ~~WIP~~ PR brings the operator up to speed with the auth changes in container-jfr since https://github.com/rh-jmc-team/container-jfr/pull/86 .

The operator now includes its serviceaccount token on the command channel connection that the flightrecorder controller uses. Without this the updated container-jfr container will reject the websocket handshake, since the user issuing the request cannot be authenticated and the request authorized.

~~WIP because there's still a TODO regarding certificate verification for TLS on the websocket connection. In CRC at least, the certificate used by the cluster is somehow invalid (probably self-signed, haven't checked the exact reason yet), so the operator's websocket client refuses the connection on its end before getting to the handshake rejection due to lack of authz. The PR currently unconditionally disables cert verification.~~