### PR TITLE
Podman image builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ openapi:
 
 .PHONY: image
 image: generate
-	operator-sdk build $(IMAGE_TAG)
+	operator-sdk build --image-builder podman $(IMAGE_TAG)
 
 .PHONY: bundle
 bundle: image copy-crds

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ at the URL provided by
 - `go`
 - [operator-sdk](https://github.com/operator-framework/operator-sdk) v0.11.0
 - [operator-courier](https://github.com/operator-framework/operator-courier) 2.1.7+
+- `podman`
 
 ## Instructions
 `make image` will create an OCI image to the local registry, tagged as
@@ -40,8 +41,8 @@ can be easily deployed.
 # Development
 An invocation like
 `export IMAGE_TAG=quay.io/some-user/container-jfr-operator`
-`make clean image && docker image push $IMAGE_TAG && make deploy`
-is handy for local development testing using ex. Minishift.
+`make clean image && podman image push $IMAGE_TAG && make deploy`
+is handy for local development testing using ex. CodeReady Containers.
 
 # Testing
 ## Requirements


### PR DESCRIPTION
~~This is based on top of the currently open Auth PR #45 . Only the last commit is new for this branch.~~

This simply adds the image-builder arg to the operator-sdk invocation, with `podman` specified as the image builder rather than the default Docker. This is motivated by `podman` requiring less setup, being rootless/daemonless, and along that same line, with Docker being incompatible with cgroupsv2 and therefore not currently working by default in Fedora 31. Since I'm using Fedora 31 this is a convenience win for me, but it also seems like a net benefit in general.