### PR TITLE
Target jmx named port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ deploy: undeploy
 	oc create -f deploy/crds/rhjmc.redhat.com_v1alpha1_containerjfr_cr.yaml
 
 .PHONY: undeploy
-undeploy: undeploy_sample_app
+undeploy: undeploy_sample_app undeploy_sample_app2
 	- oc delete deployment container-jfr-operator
 	- oc delete containerjfr --all
 	- oc delete flightrecorder --all
@@ -91,3 +91,12 @@ sample_app:
 .PHONY: undeploy_sample_app
 undeploy_sample_app:
 	- oc delete all -l app=vertx-fib-demo
+
+.PHONY: sample_app2
+sample_app2:
+	oc new-app andrewazores/container-jmx-docker-listener:latest --name=jmx-listener
+	oc patch svc/jmx-listener -p '{"spec":{"$setElementOrder/ports":[{"port":7095},{"port":9092},{"port":9093}],"ports":[{"name":"jmx","port":9093}]}}'
+
+.PHONY: undeploy_sample_app2
+undeploy_sample_app2:
+	- oc delete all -l app=jmx-listener

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ undeploy_sample_app:
 .PHONY: sample_app2
 sample_app2:
 	oc new-app andrewazores/container-jmx-docker-listener:latest --name=jmx-listener
-	oc patch svc/jmx-listener -p '{"spec":{"$setElementOrder/ports":[{"port":7095},{"port":9092},{"port":9093}],"ports":[{"name":"jmx","port":9093}]}}'
+	oc patch svc/jmx-listener -p '{"spec":{"$setElementOrder/ports":[{"port":7095},{"port":9092},{"port":9093}],"ports":[{"name":"jfr-jmx","port":9093}]}}'
 
 .PHONY: undeploy_sample_app2
 undeploy_sample_app2:

--- a/deploy/crds/rhjmc.redhat.com_flightrecorders_crd.yaml
+++ b/deploy/crds/rhjmc.redhat.com_flightrecorders_crd.yaml
@@ -31,6 +31,10 @@ spec:
         spec:
           description: FlightRecorderSpec defines the desired state of FlightRecorder
           properties:
+            port:
+              description: JMX port for target JVM
+              format: int32
+              type: integer
             recordingRequests:
               description: Requests to create new flight recordings
               items:
@@ -57,6 +61,7 @@ spec:
                 type: object
               type: array
           required:
+          - port
           - recordingRequests
           type: object
         status:

--- a/pkg/apis/rhjmc/v1alpha1/flightrecorder_types.go
+++ b/pkg/apis/rhjmc/v1alpha1/flightrecorder_types.go
@@ -15,6 +15,8 @@ type FlightRecorderSpec struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
 
+	// JMX port for target JVM
+	Port int32 `json:"port"`
 	// Requests to create new flight recordings
 	// +listType=set
 	Requests []RecordingRequest `json:"recordingRequests"`

--- a/pkg/apis/rhjmc/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/rhjmc/v1alpha1/zz_generated.openapi.go
@@ -146,6 +146,13 @@ func schema_pkg_apis_rhjmc_v1alpha1_FlightRecorderSpec(ref common.ReferenceCallb
 				Description: "FlightRecorderSpec defines the desired state of FlightRecorder",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"port": {
+						SchemaProps: spec.SchemaProps{
+							Description: "JMX port for target JVM",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"recordingRequests": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -165,7 +172,7 @@ func schema_pkg_apis_rhjmc_v1alpha1_FlightRecorderSpec(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"recordingRequests"},
+				Required: []string{"port", "recordingRequests"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/client/containerjfr_client.go
+++ b/pkg/client/containerjfr_client.go
@@ -70,7 +70,7 @@ func newWebSocketConn(server *url.URL, token *string, tlsVerify bool) (*websocke
 }
 
 // Connect tells Container JFR to connect to a JVM addressed by the host and port
-func (client *ContainerJfrClient) Connect(host string, port int) error {
+func (client *ContainerJfrClient) Connect(host string, port int32) error {
 	// Disconnect first if already connected
 	connected, err := client.isConnected()
 	if err != nil {

--- a/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
+++ b/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
@@ -254,12 +254,12 @@ func NewExporterService(cr *rhjmcv1alpha1.ContainerJFR) *corev1.Service {
 			},
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "8181-tcp",
+					Name:       "export",
 					Port:       8181,
 					TargetPort: intstr.IntOrString{IntVal: 8181},
 				},
 				{
-					Name:       "9091-tcp",
+					Name:       "jmx",
 					Port:       9091,
 					TargetPort: intstr.IntOrString{IntVal: 9091},
 				},
@@ -285,7 +285,7 @@ func NewCommandChannelService(cr *rhjmcv1alpha1.ContainerJFR) *corev1.Service {
 			},
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "9090-tcp",
+					Name:       "cmdchan",
 					Port:       9090,
 					TargetPort: intstr.IntOrString{IntVal: 9090},
 				},

--- a/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
+++ b/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
@@ -259,7 +259,7 @@ func NewExporterService(cr *rhjmcv1alpha1.ContainerJFR) *corev1.Service {
 					TargetPort: intstr.IntOrString{IntVal: 8181},
 				},
 				{
-					Name:       "jmx",
+					Name:       "jfr-jmx",
 					Port:       9091,
 					TargetPort: intstr.IntOrString{IntVal: 9091},
 				},

--- a/pkg/controller/flightrecorder/flightrecorder_controller.go
+++ b/pkg/controller/flightrecorder/flightrecorder_controller.go
@@ -70,9 +70,6 @@ type ReconcileFlightRecorder struct {
 	jfrClient *jfrclient.ContainerJfrClient
 }
 
-// FIXME this constant is duplicated here and in service_controller
-const defaultRemoteJmxPort = 9091
-
 // Reconcile reads that state of the cluster for a FlightRecorder object and makes changes based on the state read
 // and what is in the FlightRecorder.Spec
 // Note:
@@ -124,7 +121,7 @@ func (r *ReconcileFlightRecorder) Reconcile(request reconcile.Request) (reconcil
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	jmxPort := getJmxPort(targetSvc)
+	jmxPort := instance.Spec.Port
 	err = r.jfrClient.Connect(*clusterIP, jmxPort)
 	if err != nil {
 		log.Error(err, "failed to connect to target JVM")
@@ -266,15 +263,6 @@ func getClusterIP(svc *corev1.Service) (*string, error) {
 		return nil, fmt.Errorf("ClusterIP unavailable for %s", svc.Name)
 	}
 	return &clusterIP, nil
-}
-
-func getJmxPort(svc *corev1.Service) int32 {
-	for _, port := range svc.Spec.Ports {
-		if port.Name == "jmx" {
-			return port.Port
-		}
-	}
-	return defaultRemoteJmxPort
 }
 
 func createRecordingInfo(descriptors []jfrclient.RecordingDescriptor) []rhjmcv1alpha1.RecordingInfo {

--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -139,11 +139,14 @@ func (r *ReconcileService) Reconcile(request reconcile.Request) (reconcile.Resul
 	return reconcile.Result{}, nil
 }
 
-const containerJFRPort int = 9091 // TODO make a property in ContainerJFR CRD?
+const defaultContainerJFRPort int = 9091
 
 func isJFRAwareService(svc *corev1.Service) bool {
 	for _, port := range svc.Spec.Ports {
-		if port.TargetPort.IntValue() == containerJFRPort {
+		if port.Name == "jmx" {
+			return true
+		}
+		if port.TargetPort.IntValue() == defaultContainerJFRPort {
 			return true
 		}
 	}

--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -139,6 +139,7 @@ func (r *ReconcileService) Reconcile(request reconcile.Request) (reconcile.Resul
 	return reconcile.Result{}, nil
 }
 
+// FIXME this constant is duplicated here and in flightrecorder_controller
 const defaultContainerJFRPort int = 9091
 
 func isJFRAwareService(svc *corev1.Service) bool {

--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -151,10 +151,11 @@ func isJFRAwareService(svc *corev1.Service) bool {
 }
 
 const defaultContainerJFRPort int32 = 9091
+const jmxServicePortName = "jfr-jmx"
 
 func getServiceJMXPort(svc *corev1.Service) (int32, error) {
 	for _, port := range svc.Spec.Ports {
-		if port.Name == "jmx" {
+		if port.Name == jmxServicePortName {
 			return port.Port, nil
 		}
 		if port.TargetPort.IntValue() == int(defaultContainerJFRPort) {


### PR DESCRIPTION
This is based on top of the currently open ~~Auth #45 and~~ podman builder #46 PRs.

The last ~~two~~ three commits in this branch replace the hardcoded exporter port number 8181 and JMX port number 9091 with named ports.

For the JMX target port of 9091, this is now used as a fallback rather than a hardcoded default. The service_controller still watches for new services to appear and for each new service it checks all of the defined service ports. If a port named "jmx" is found then the service is marked as a compatible target. If no "jmx" port is found but the 9091 port is found then it is also marked as compatible. If neither are found then the service is ignored as a potential target. Then, after the service_controller creates the FlightRecorder resource including this port number, the flightrecorder_controller (watching for new FlightRecorder CRs) reconcile is triggered, which uses this port number for establishing the target connection via ContainerJFR.

~~This part is still WIP since the default 9091 fallback port number constant is hardcoded in both controllers. I intend to resolve this by adding the port number to the FlightRecorder CRD, so that the service_controller can include the port number in the CR upon creation, and this way pass the port number to the flightrecorder_controller and avoid the duplicate fallback logic.~~

For the exporter 8181 port, the flightrecorder_controller assumes that the owned ContainerJFR instance will have a port named "export", which is simply the same existing port definition on 8181 as before, but renamed from "8181-tcp" to "export". This allows the controller to connect to the ContainerJFR instance even if the webserver port is changed in the future without requiring an update to the controller code.