### PR TITLE
Register OpenShift route scheme with manager in place of route client

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rh-jmc-team/container-jfr-operator/pkg/apis"
 	"github.com/rh-jmc-team/container-jfr-operator/pkg/controller"
 
+	routev1 "github.com/openshift/api/route/v1"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
@@ -25,8 +26,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
@@ -103,6 +104,12 @@ func main() {
 
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	// Add OpenShift route/v1 scheme
+	if err := routev1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}

--- a/go.mod
+++ b/go.mod
@@ -34,5 +34,3 @@ replace (
 )
 
 replace github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.11.0
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ require (
 	github.com/go-openapi/spec v0.17.2
 	github.com/gorilla/websocket v1.4.1
 	github.com/openshift/api v3.9.0+incompatible
-	github.com/openshift/client-go v3.9.0+incompatible
 	github.com/operator-framework/operator-sdk v0.11.0
 	github.com/spf13/pflag v1.0.3
 	k8s.io/api v0.0.0-20190918155943-95b840bb6a1f
@@ -35,3 +34,5 @@ replace (
 )
 
 replace github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.11.0
+
+go 1.13

--- a/pkg/controller/containerjfr/containerjfr_controller.go
+++ b/pkg/controller/containerjfr/containerjfr_controller.go
@@ -7,7 +7,6 @@ import (
 
 	goerrors "errors"
 	openshiftv1 "github.com/openshift/api/route/v1"
-	routeClient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	rhjmcv1alpha1 "github.com/rh-jmc-team/container-jfr-operator/pkg/apis/rhjmc/v1alpha1"
 	resources "github.com/rh-jmc-team/container-jfr-operator/pkg/controller/containerjfr/resource_definitions"
 	appsv1 "k8s.io/api/apps/v1"
@@ -36,8 +35,7 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	rc := routeClient.NewForConfigOrDie(mgr.GetConfig())
-	return &ReconcileContainerJFR{client: mgr.GetClient(), routeClient: *rc, scheme: mgr.GetScheme()}
+	return &ReconcileContainerJFR{client: mgr.GetClient(), scheme: mgr.GetScheme()}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -74,9 +72,8 @@ var _ reconcile.Reconciler = &ReconcileContainerJFR{}
 type ReconcileContainerJFR struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	client      client.Client
-	routeClient routeClient.RouteV1Client
-	scheme      *runtime.Scheme
+	client client.Client
+	scheme *runtime.Scheme
 }
 
 // Reconcile reads that state of the cluster for a ContainerJFR object and makes changes based on the state read
@@ -146,7 +143,13 @@ func (r *ReconcileContainerJFR) Reconcile(request reconcile.Request) (reconcile.
 		}
 		for _, svc := range services {
 			reqLogger.Info("Deleting existing non-minimal route", "route.Name", svc.Name)
-			err = r.routeClient.Routes(svc.Namespace).Delete(svc.Name, metav1.NewDeleteOptions(0))
+			route := &openshiftv1.Route{}
+			err = r.client.Get(context.Background(), types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}, route)
+			if err != nil && !errors.IsNotFound(err) {
+				reqLogger.Info("Non-minimal could not be retrieved", "route.Name", svc.Name)
+				return reconcile.Result{}, err
+			}
+			err = r.client.Delete(context.Background(), route)
 			if err != nil && !errors.IsNotFound(err) {
 				reqLogger.Info("Could not delete non-minimal route", "route.Name", svc.Name)
 				return reconcile.Result{}, err
@@ -249,16 +252,19 @@ func (r *ReconcileContainerJFR) createRouteForService(controller *rhjmcv1alpha1.
 		return "", err
 	}
 
-	rc := r.routeClient.Routes(svc.Namespace)
-	found, err := rc.Get(svc.Name, metav1.GetOptions{})
+	found := &openshiftv1.Route{}
+	err := r.client.Get(context.Background(), types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}, found)
 	if err != nil && errors.IsNotFound(err) {
 		logger.Info("Not found")
-		if created, err := rc.Create(route); err != nil {
+		if err := r.client.Create(context.Background(), route); err != nil {
 			logger.Error(err, "Could not be created")
 			return "", err
-		} else {
-			logger.Info("Created")
-			found = created
+		}
+		logger.Info("Created")
+		err = r.client.Get(context.Background(), types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}, found)
+		if err != nil {
+			logger.Error(err, "Failed to get newly created route", "name", svc.Name)
+			return "", err
 		}
 	} else if err != nil {
 		logger.Error(err, "Could not be read")

--- a/pkg/controller/containerjfr/containerjfr_controller.go
+++ b/pkg/controller/containerjfr/containerjfr_controller.go
@@ -146,13 +146,14 @@ func (r *ReconcileContainerJFR) Reconcile(request reconcile.Request) (reconcile.
 			route := &openshiftv1.Route{}
 			err = r.client.Get(context.Background(), types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}, route)
 			if err != nil && !errors.IsNotFound(err) {
-				reqLogger.Info("Non-minimal could not be retrieved", "route.Name", svc.Name)
+				reqLogger.Info("Non-minimal route could not be retrieved", "route.Name", svc.Name)
 				return reconcile.Result{}, err
-			}
-			err = r.client.Delete(context.Background(), route)
-			if err != nil && !errors.IsNotFound(err) {
-				reqLogger.Info("Could not delete non-minimal route", "route.Name", svc.Name)
-				return reconcile.Result{}, err
+			} else if err == nil {
+				err = r.client.Delete(context.Background(), route)
+				if err != nil && !errors.IsNotFound(err) {
+					reqLogger.Info("Could not delete non-minimal route", "route.Name", svc.Name)
+					return reconcile.Result{}, err
+				}
 			}
 
 			err = r.client.Get(context.Background(), types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}, svc)


### PR DESCRIPTION
This PR modifies the ContainerJFR and Grafana controllers to operate on routes using the manager's client instead of needing a separate clientset. This is done by adding the `route/v1` scheme to our manager's scheme. This also allows us to remove the dependency on openshift/client-go.