### PR TITLE
Remove unnecessary Get call after creating route

### DIFF
--- a/pkg/controller/containerjfr/containerjfr_controller.go
+++ b/pkg/controller/containerjfr/containerjfr_controller.go
@@ -262,11 +262,7 @@ func (r *ReconcileContainerJFR) createRouteForService(controller *rhjmcv1alpha1.
 			return "", err
 		}
 		logger.Info("Created")
-		err = r.client.Get(context.Background(), types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}, found)
-		if err != nil {
-			logger.Error(err, "Failed to get newly created route", "name", svc.Name)
-			return "", err
-		}
+		found = route
 	} else if err != nil {
 		logger.Error(err, "Could not be read")
 		return "", err


### PR DESCRIPTION
I noticed errors of the form `{"level":"error","ts":1579803672.526808,"logger":"controller_containerjfr","msg":"Failed to get newly created route"...` appearing in the log after creating new routes. I suspect this has something to do with the controller's client reading from a cache [1]. Fortunately, it looks like this Get call after Create is unnecessary. The Create call has a side-effect of updating the provided runtime object with a full copy provided by the API server.

Before Create call:
```json
{
  "metadata": {
    "name": "containerjfr-command",
    "namespace": "default",
    "creationTimestamp": null,
    "ownerReferences": [
      {
        "apiVersion": "rhjmc.redhat.com/v1alpha1",
        "kind": "ContainerJFR",
        "name": "containerjfr",
        "uid": "3184c6b5-3e2a-11ea-a9c4-52fdfc072182",
        "controller": true,
        "blockOwnerDeletion": true
      }
    ]
  },
  "spec": {
    "host": "",
    "to": {
      "kind": "Service",
      "name": "containerjfr-command",
      "weight": null
    },
    "port": {
      "targetPort": 9090
    },
    "tls": {
      "termination": "edge",
      "insecureEdgeTerminationPolicy": "Redirect"
    }
  },
  "status": {
    "ingress": null
  }
}
```
After Create call (creationTimestamp and other fields now populated):
```json
{
  "metadata": {
    "name": "containerjfr-command",
    "namespace": "default",
    "selfLink": "/apis/route.openshift.io/v1/namespaces/default/routes/containerjfr-command",
    "uid": "47e0c1f5-3e2a-11ea-ba0e-0a580a8000b1",
    "resourceVersion": "130798",
    "creationTimestamp": "2020-01-23T21:49:50Z",
    "annotations": {
      "openshift.io/host.generated": "true"
    },
    "ownerReferences": [
      {
        "apiVersion": "rhjmc.redhat.com/v1alpha1",
        "kind": "ContainerJFR",
        "name": "containerjfr",
        "uid": "3184c6b5-3e2a-11ea-a9c4-52fdfc072182",
        "controller": true,
        "blockOwnerDeletion": true
      }
    ]
  },
  "spec": {
    "host": "containerjfr-command-default.apps-crc.testing",
    "to": {
      "kind": "Service",
      "name": "containerjfr-command",
      "weight": 100
    },
    "port": {
      "targetPort": 9090
    },
    "tls": {
      "termination": "edge",
      "insecureEdgeTerminationPolicy": "Redirect"
    },
    "wildcardPolicy": "None"
  },
  "status": {
    "ingress": null
  }
}
```

[1] https://godoc.org/sigs.k8s.io/controller-runtime/pkg/client