### PR TITLE
Use a UUID when communicating with command server

### DIFF
--- a/deploy/dev_operator.yaml
+++ b/deploy/dev_operator.yaml
@@ -20,6 +20,8 @@ spec:
           image: REPLACE_IMAGE
           command:
           - container-jfr-operator
+          args:
+          - "--zap-level=debug"
           imagePullPolicy: Always
           env:
             - name: TLS_VERIFY

--- a/pkg/client/command_types.go
+++ b/pkg/client/command_types.go
@@ -131,7 +131,7 @@ func (msg *ResponseMessage) UnmarshalJSON(data []byte) error {
 	// to parse a response which could contain a different kind of
 	// payload
 	if msg.ID != peek.ID {
-		log.Info("Skipping response with unexpected ID", "expected", msg.ID,
+		debugLog.Info("Skipping response with unexpected ID", "expected", msg.ID,
 			"actual", peek.ID)
 		return ErrWrongID
 	}

--- a/pkg/client/command_types.go
+++ b/pkg/client/command_types.go
@@ -2,11 +2,16 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
 )
 
 // CommandMessage represents the body of a command request to be sent
 // to Container JFR
 type CommandMessage struct {
+	// ID used to uniquely identify a response to this message
+	ID types.UID `json:"id"`
 	// The name of the command, must be recognized by Container JFR
 	Command string `json:"command"`
 	// Any arguments that Container JFR accepts for the named command
@@ -16,7 +21,7 @@ type CommandMessage struct {
 // NewCommandMessage provides a conventient shorthand for constructing
 // new CommandMessages
 func NewCommandMessage(command string, args ...string) *CommandMessage {
-	return &CommandMessage{Command: command, Args: args}
+	return &CommandMessage{ID: uuid.NewUUID(), Command: command, Args: args}
 }
 
 // ResponseStatus is a response code used by Container JFR to indiciate
@@ -38,6 +43,8 @@ const (
 // ResponseMessage corresponds to the response from Container JFR to
 // a command message previously sent
 type ResponseMessage struct {
+	// Identifier of the command message that triggered this response
+	ID types.UID `json:"id"`
 	// The name of the command that this message is responding to
 	CommandName string `json:"commandName"`
 	// The response code showing whether this command succeeded
@@ -102,18 +109,33 @@ type SavedRecording struct {
 	ReportURL   string `json:"reportUrl"`
 }
 
+// ErrWrongID is returned when a JSON response has an unexpected ID
+var ErrWrongID error = errors.New("Response in reply to different command")
+
 // UnmarshalJSON overrides standard JSON parsing to handle error payloads
+// and filter out messages intended for other clients.
+// The receiver's ID should be populated with the command message's ID
+// and the Payload should be set to the expected type's zero value.
 func (msg *ResponseMessage) UnmarshalJSON(data []byte) error {
-	// Unmarshall only status at first to determine if we need to
-	// parse an error string
-	peekStatus := struct {
-		Status int `json:"status"`
+	// Unmarshall ID to check if we are the intended recipient, and
+	// also status to determine if we need to parse an error string
+	peek := struct {
+		ID     types.UID `json:"id"`
+		Status int       `json:"status"`
 	}{}
-	err := json.Unmarshal(data, &peekStatus)
+	err := json.Unmarshal(data, &peek)
 	if err != nil {
 		return err
 	}
-	if peekStatus.Status < 0 {
+	// By checking the ID here, we can abort early and not attempt
+	// to parse a response which could contain a different kind of
+	// payload
+	if msg.ID != peek.ID {
+		log.Info("Skipping response with unexpected ID", "expected", msg.ID,
+			"actual", peek.ID)
+		return ErrWrongID
+	}
+	if peek.Status < 0 {
 		// Expect a string payload for non-zero status
 		msg.Payload = ""
 	}


### PR DESCRIPTION
This PR takes advantage of the ID field added to command messages with https://github.com/rh-jmc-team/container-jfr/pull/117. We generate a UUID upon creating a CommandMessage using apimachinery's UUID util package.

When reading a response, we set this expected ID in the response struct that our decoder will attempt to unmarshal into. This allows our custom JSON decoder to verify the read ID is what we're expected before attempting to unmarshal the rest of the response. This prevents us from unmarshalling an unexpected payload type.

If the ID in the response is not what we're expecting, we return a special error indicating that the message was meant for another client. Our client will read in a loop until we receive the correct response, or some other error occurs. This seems to work well, but I'm a bit concerned something goes wrong and our client loops endlessly. Perhaps we should set some kind of timeout?