### PR TITLE
Use generated Grafana credentials, not default

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ API to manage [JDK Flight Recordings](https://openjdk.java.net/jeps/328).
 # Using
 Once deployed, the `containerjfr` instance can be accessed via web browser
 at the URL provided by
-`oc get pod -l kind=containerjfr -o jsonpath='http://{$.items[0].metadata.annotations.redhat\.com/containerJfrUrl} '`
+`oc get pod -l kind=containerjfr -o jsonpath='http://{$.items[0].metadata.annotations.redhat\.com/containerJfrUrl} '`.
+The Grafana credentials can be obtained with:
+`oc get secret containerjfr-grafana-basic -o jsonpath='{$.data.GF_SECURITY_ADMIN_USER}' | base64 -d`
+and
+`oc get secret containerjfr-grafana-basic -o jsonpath='{$.data.GF_SECURITY_ADMIN_PASSWORD}' | base64 -d`.
 
 # Building
 ## Requirements

--- a/pkg/controller/containerjfr/containerjfr_controller.go
+++ b/pkg/controller/containerjfr/containerjfr_controller.go
@@ -107,6 +107,14 @@ func (r *ReconcileContainerJFR) Reconcile(request reconcile.Request) (reconcile.
 		return reconcile.Result{}, err
 	}
 
+	grafanaSecret := resources.NewGrafanaSecretForCR(instance)
+	if err := controllerutil.SetControllerReference(instance, grafanaSecret, r.scheme); err != nil {
+		return reconcile.Result{}, err
+	}
+	if err = r.createObjectIfNotExists(context.Background(), types.NamespacedName{Name: grafanaSecret.Name, Namespace: grafanaSecret.Namespace}, &corev1.Secret{}, grafanaSecret); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	serviceSpecs := &resources.ServiceSpecs{}
 	var url string
 	if !instance.Spec.Minimal {


### PR DESCRIPTION
See #50 and #51 . This PR results in Grafana being configured to use a generated
password rather than the insecure default credentials for its normal HTTP Basic
auth scheme. The generated password is stored in a Secret, with the contents
written into the Grafana container's environment variables. These generated
credentials are also retrieved and used by the Operator itself when it performs
its startup configuration of the Grafana instance (creating the datasource
and dashboard).