### PR TITLE
Update container-jfr image version

### DIFF
--- a/deploy/crds/rhjmc.redhat.com_v1alpha2_recording_cr.yaml
+++ b/deploy/crds/rhjmc.redhat.com_v1alpha2_recording_cr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-recording
 spec:
   name: example-recording
-  eventOptions: [ ALL ]
+  eventOptions: [ "template=ALL" ]
   duration: 30s
   archive: true
   flightRecorder:

--- a/pkg/client/command_types.go
+++ b/pkg/client/command_types.go
@@ -56,7 +56,13 @@ type CommandMessage struct {
 
 // NewCommandMessage provides a conventient shorthand for constructing
 // new CommandMessages
-func NewCommandMessage(command string, args ...string) *CommandMessage {
+func NewCommandMessage(command string, targetID string, args ...string) *CommandMessage {
+	return NewControlMessage(command, append([]string{targetID}, args...)...)
+}
+
+// NewControlMessage provides a convenient shorthand for constructing
+// new control CommandMessages, which do not include a targetID
+func NewControlMessage(command string, args ...string) *CommandMessage {
 	return &CommandMessage{ID: uuid.NewUUID(), Command: command, Args: args}
 }
 

--- a/pkg/controller/common/common_reconciler.go
+++ b/pkg/controller/common/common_reconciler.go
@@ -150,7 +150,7 @@ func (r *CommonReconciler) getClientURL(ctx context.Context, namespace string, s
 	if err != nil {
 		return nil, err
 	}
-	host := fmt.Sprintf("http://%s:%d/clienturl", *clusterIP, webServerPort)
+	host := fmt.Sprintf("http://%s:%d/api/v1/clienturl", *clusterIP, webServerPort)
 	resp, err := http.Get(host)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
+++ b/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
@@ -192,7 +192,7 @@ func NewCoreContainer(cr *rhjmcv1alpha1.ContainerJFR, specs *ServiceSpecs) corev
 			Value: specs.DatasourceAddress,
 		},
 	}
-	imageTag := "quay.io/rh-jmc-team/container-jfr:0.16.0"
+	imageTag := "quay.io/rh-jmc-team/container-jfr:0.19.0"
 	if cr.Spec.Minimal {
 		imageTag += "-minimal"
 		envs = append(envs, corev1.EnvVar{
@@ -225,7 +225,7 @@ func NewCoreContainer(cr *rhjmcv1alpha1.ContainerJFR, specs *ServiceSpecs) corev
 			Handler: corev1.Handler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Port: intstr.IntOrString{IntVal: 8181},
-					Path: "/clienturl",
+					Path: "/api/v1/clienturl",
 				},
 			},
 		},


### PR DESCRIPTION
Also update controllers for updated connectionless API, currently
emulating a connection-oriented interface by holding internal state.
Finally, also replaces "ALL" event string with "template=ALL".