### PR TITLE
Create version 0.5.0 and minor fixes

### DIFF
--- a/.osdk-scorecard.yaml
+++ b/.osdk-scorecard.yaml
@@ -8,10 +8,12 @@ scorecard:
             crds-dir: "deploy/crds"
             cr-manifest:
                 - "deploy/crds/rhjmc.redhat.com_v1alpha1_containerjfr_cr.yaml"
-                - "deploy/crds/rhjmc.redhat.com_v1alpha1_flightrecorder_cr.yaml"
+                - "deploy/crds/rhjmc.redhat.com_v1alpha2_flightrecorder_cr.yaml"
+                - "deploy/crds/rhjmc.redhat.com_v1alpha2_recording_cr.yaml"
         - olm:
             crds-dir: "deploy/crds"
             cr-manifest:
                 - "deploy/crds/rhjmc.redhat.com_v1alpha1_containerjfr_cr.yaml"
-                - "deploy/crds/rhjmc.redhat.com_v1alpha1_flightrecorder_cr.yaml"
-            csv-path: "deploy/olm-catalog/container-jfr-operator-bundle/0.4.0/container-jfr-operator-bundle.v0.4.0.clusterserviceversion.yaml"
+                - "deploy/crds/rhjmc.redhat.com_v1alpha2_flightrecorder_cr.yaml"
+                - "deploy/crds/rhjmc.redhat.com_v1alpha2_recording_cr.yaml"
+            csv-path: "deploy/olm-catalog/container-jfr-operator-bundle/0.5.0/container-jfr-operator-bundle.v0.5.0.clusterserviceversion.yaml"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE_STREAM ?= quay.io/rh-jmc-team/container-jfr-operator
-IMAGE_VERSION ?= 0.4.0
+IMAGE_VERSION ?= 0.5.0
 IMAGE_TAG ?= $(IMAGE_STREAM):$(IMAGE_VERSION)
 
 BUNDLE_STREAM ?= $(IMAGE_STREAM)-bundle
@@ -7,7 +7,7 @@ CSV_VERSION ?= $(IMAGE_VERSION)
 PREV_CSV_VERSION ?= $(CSV_VERSION)
 
 INDEX_STREAM ?= $(IMAGE_STREAM)-index
-INDEX_VERSION ?= 0.0.1
+INDEX_VERSION ?= 0.0.2
 PREV_INDEX_VERSION ?= $(INDEX_VERSION)
 
 BUILDER ?= podman
@@ -125,6 +125,7 @@ deploy: undeploy
 undeploy: undeploy_sample_app undeploy_sample_app2
 	- oc delete deployment container-jfr-operator
 	- oc delete containerjfr --all
+	- oc delete recording --all
 	- oc delete flightrecorder --all
 	- oc delete all -l name=container-jfr-operator
 	- oc delete all -l app=containerjfr

--- a/deploy/olm-catalog/catalog-source.yaml
+++ b/deploy/olm-catalog/catalog-source.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: default
 spec:
   sourceType: grpc
-  image: quay.io/rh-jmc-team/container-jfr-operator-index:0.0.1
+  image: quay.io/rh-jmc-team/container-jfr-operator-index:0.0.2

--- a/deploy/olm-catalog/container-jfr-operator-bundle/0.5.0/container-jfr-operator-bundle.v0.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/container-jfr-operator-bundle/0.5.0/container-jfr-operator-bundle.v0.5.0.clusterserviceversion.yaml
@@ -1,0 +1,217 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "rhjmc.redhat.com/v1alpha1",
+          "kind": "ContainerJFR",
+          "metadata": {
+            "name": "containerjfr"
+          },
+          "spec": {
+            "minimal": false
+          }
+        },
+        {
+          "apiVersion": "rhjmc.redhat.com/v1alpha2",
+          "kind": "FlightRecorder",
+          "metadata": {
+            "name": "example-flightrecorder"
+          },
+          "spec": {
+            "recordingSelector": {
+              "matchLabels": {
+                "rhjmc.redhat.com/flightrecorder": "example-flightrecorder"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "rhjmc.redhat.com/v1alpha2",
+          "kind": "Recording",
+          "metadata": {
+            "name": "example-recording"
+          },
+          "spec": {
+            "archive": true,
+            "duration": "30s",
+            "eventOptions": [
+              "template=ALL"
+            ],
+            "flightRecorder": {
+              "name": "example-flightrecorder"
+            },
+            "name": "example-recording"
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: Monitoring, Developer Tools
+    certified: "false"
+    containerImage: quay.io/rh-jmc-team/container-jfr-operator:0.5.0
+    createdAt: "2020-07-03 00:00:00"
+    description: JVM monitoring and profiling tool
+    repository: github.com/rh-jmc-team/container-jfr-operator
+    support: Red Hat
+  name: container-jfr-operator-bundle.v0.5.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: ContainerJFR is the Schema for the containerjfrs API
+      kind: ContainerJFR
+      name: containerjfrs.rhjmc.redhat.com
+      version: v1alpha1
+    - description: FlightRecorder is the Schema for the flightrecorders API
+      kind: FlightRecorder
+      name: flightrecorders.rhjmc.redhat.com
+      version: v1alpha2
+    - description: Recording is the Schema for the recordings API
+      kind: Recording
+      name: recordings.rhjmc.redhat.com
+      version: v1alpha2
+  description: |
+    ContainerJFR provides a cloud-based solution for interacting with the JDK Flight Recorder already present in OpenJDK 11+ JVMs. With ContainerJFR, users can remotely start, stop, retrieve, and even analyze JFR event data, providing the capbility to easily take advantage of Flight Recorder''s extremely low runtime cost and overhead and the flexibility to monitor applications and analyze recording data without transferring data outside of the cluster the application runs within.
+  displayName: ContainerJFR
+  icon:
+  - base64data: ""
+    mediatype: image/png
+  install:
+    spec:
+      deployments:
+      - name: container-jfr-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: container-jfr-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: container-jfr-operator
+            spec:
+              containers:
+              - command:
+                - container-jfr-operator
+                env:
+                - name: TLS_VERIFY
+                  value: "true"
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: container-jfr-operator
+                image: quay.io/rh-jmc-team/container-jfr-operator:0.5.0
+                imagePullPolicy: Always
+                name: container-jfr-operator
+                resources: {}
+              serviceAccountName: container-jfr-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - routes
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - container-jfr-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          verbs:
+          - get
+        - apiGroups:
+          - rhjmc.redhat.com
+          resources:
+          - '*'
+          - flightrecorders
+          - recordings
+          verbs:
+          - '*'
+        serviceAccountName: container-jfr-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - flightrecorder
+  - java
+  - jdk
+  - jfr
+  - jmc
+  - missioncontrol
+  - monitoring
+  - profiling
+  links:
+  - name: Upstream Project
+    url: https://github.com/rh-jmc-team/container-jfr
+  maintainers:
+  - email: aazores@redhat.com
+    name: Andrew Azores
+  - email: ebaron@redhat.com
+    name: Elliott Baron
+  maturity: pre-alpha
+  provider:
+    name: Red Hat
+  replaces: container-jfr-operator-bundle.v0.4.0
+  selector: {}
+  version: 0.5.0

--- a/deploy/olm-catalog/container-jfr-operator-bundle/0.5.0/rhjmc.redhat.com_containerjfrs_crd.yaml
+++ b/deploy/olm-catalog/container-jfr-operator-bundle/0.5.0/rhjmc.redhat.com_containerjfrs_crd.yaml
@@ -1,0 +1,47 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: containerjfrs.rhjmc.redhat.com
+spec:
+  group: rhjmc.redhat.com
+  names:
+    kind: ContainerJFR
+    listKind: ContainerJFRList
+    plural: containerjfrs
+    singular: containerjfr
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ContainerJFR is the Schema for the containerjfrs API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ContainerJFRSpec defines the desired state of ContainerJFR
+          properties:
+            minimal:
+              type: boolean
+          required:
+          - minimal
+          type: object
+        status:
+          description: ContainerJFRStatus defines the observed state of ContainerJFR
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/container-jfr-operator-bundle/0.5.0/rhjmc.redhat.com_flightrecorders_crd.yaml
+++ b/deploy/olm-catalog/container-jfr-operator-bundle/0.5.0/rhjmc.redhat.com_flightrecorders_crd.yaml
@@ -1,0 +1,187 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: flightrecorders.rhjmc.redhat.com
+spec:
+  group: rhjmc.redhat.com
+  names:
+    kind: FlightRecorder
+    listKind: FlightRecorderList
+    plural: flightrecorders
+    singular: flightrecorder
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: FlightRecorder is the Schema for the flightrecorders API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: FlightRecorderSpec defines the desired state of FlightRecorder
+          properties:
+            recordingSelector:
+              description: Recordings that match this selector belong to this FlightRecorder
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+          required:
+          - recordingSelector
+          type: object
+        status:
+          description: FlightRecorderStatus defines the observed state of FlightRecorder
+          properties:
+            events:
+              description: Listing of events available in the target JVM
+              items:
+                description: EventInfo contains metadata for a JFR event type
+                properties:
+                  category:
+                    description: A hierarchical category used to organize related
+                      event types
+                    items:
+                      type: string
+                    type: array
+                  description:
+                    description: A description detailing what this event does
+                    type: string
+                  name:
+                    description: Human-readable name for this type of event
+                    type: string
+                  options:
+                    additionalProperties:
+                      description: OptionDescriptor contains metadata for an option
+                        for a particular event type
+                      properties:
+                        defaultValue:
+                          description: The value implicitly used when this option
+                            isn't specified
+                          type: string
+                        description:
+                          description: A description of what this option does
+                          type: string
+                        name:
+                          description: Human-readable name for this option
+                          type: string
+                      required:
+                      - defaultValue
+                      - description
+                      - name
+                      type: object
+                    description: Options that may be used to tune this event. This
+                      map is indexed by the option IDs.
+                    type: object
+                  typeId:
+                    description: The ID used by JFR to uniquely identify this event
+                      type
+                    type: string
+                required:
+                - category
+                - description
+                - name
+                - options
+                - typeId
+                type: object
+              type: array
+            port:
+              description: JMX port for target JVM
+              format: int32
+              minimum: 0
+              type: integer
+            target:
+              description: Reference to the pod/service that this object controls
+                JFR for
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+          required:
+          - events
+          - port
+          - target
+          type: object
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true

--- a/deploy/olm-catalog/container-jfr-operator-bundle/0.5.0/rhjmc.redhat.com_recordings_crd.yaml
+++ b/deploy/olm-catalog/container-jfr-operator-bundle/0.5.0/rhjmc.redhat.com_recordings_crd.yaml
@@ -1,0 +1,104 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: recordings.rhjmc.redhat.com
+spec:
+  group: rhjmc.redhat.com
+  names:
+    kind: Recording
+    listKind: RecordingList
+    plural: recordings
+    singular: recording
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Recording is the Schema for the recordings API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: RecordingSpec defines the desired state of Recording
+          properties:
+            archive:
+              description: Whether this recording should be saved to persistent storage.
+                If true, the JFR file will be retained until this object is deleted.
+                If false, the JFR file will be deleted when its corresponding JVM
+                exits.
+              type: boolean
+            duration:
+              description: The requested total duration of the recording, a zero value
+                will record indefinitely.
+              type: string
+            eventOptions:
+              description: 'A list of event options to use when creating the recording.
+                These are used to enable and fine-tune individual events. Examples:
+                "jdk.ExecutionSample:enabled=true", "jdk.ExecutionSample:period=200ms"'
+              items:
+                type: string
+              type: array
+            flightRecorder:
+              description: Reference to the FlightRecorder object that corresponds
+                to this Recording
+              properties:
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    TODO: Add other useful fields. apiVersion, kind, uid?'
+                  type: string
+              type: object
+            name:
+              description: Name of the recording to be created.
+              type: string
+            state:
+              description: Desired state of the recording. If omitted, RUNNING will
+                be assumed.
+              enum:
+              - RUNNING
+              - STOPPED
+              type: string
+          required:
+          - archive
+          - duration
+          - eventOptions
+          - flightRecorder
+          - name
+          type: object
+        status:
+          description: RecordingStatus defines the observed state of Recording
+          properties:
+            downloadURL:
+              description: A URL to download the JFR file for the recording.
+              type: string
+            duration:
+              description: The duration of the recording specified during creation.
+              type: string
+            startTime:
+              description: The date/time when the recording started.
+              format: date-time
+              type: string
+            state:
+              description: Current state of the recording.
+              enum:
+              - CREATED
+              - RUNNING
+              - STOPPING
+              - STOPPED
+              type: string
+          type: object
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true

--- a/deploy/olm-catalog/container-jfr-operator-bundle/container-jfr-operator-bundle.package.yaml
+++ b/deploy/olm-catalog/container-jfr-operator-bundle/container-jfr-operator-bundle.package.yaml
@@ -1,5 +1,5 @@
 channels:
-- currentCSV: container-jfr-operator-bundle.v0.4.0
+- currentCSV: container-jfr-operator-bundle.v0.5.0
   name: alpha
 defaultChannel: alpha
 packageName: container-jfr-operator-bundle

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -9,6 +9,7 @@ rules:
   resources:
   - pods
   - services
+  - services/finalizers
   - routes
   - endpoints
   - persistentvolumeclaims


### PR DESCRIPTION
This creates a version 0.5.0 CSV and a version 0.0.2 index. I also fixed a few minor issues I detected as well.
* Remove recordings during `make undeploy`
* Missing/old CRs in scorecard config
* Re-added `services/finalizers` to Role since this is actually used by the built-in monitoring.