### PR TITLE
Add GOROOT instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ and
 - `podman`
 
 ## Instructions
+Operator SDK requires the `GOROOT` environment variable to be set to the root
+of your Go installation. In Bash, this can be done with
+`export GOROOT="$(go env GOROOT)"`.
+
 `make image` will create an OCI image to the local registry, tagged as
 `quay.io/rh-jmc-team/container-jfr-operator`. This tag can be overridden by
 setting the environment variable `IMAGE_TAG`.


### PR DESCRIPTION
Operator SDK can fail to build the operator with errors like `unsupported type invalid type for invalid type...` if the user does not have the `GOROOT` environment variable set. This PR adds defining `GOROOT` as a build instruction to the README.