### PR TITLE
Tests for FlightRecorder controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ require (
 	github.com/go-logr/logr v0.1.0
 	github.com/go-openapi/spec v0.19.4
 	github.com/gorilla/websocket v1.4.1
+	github.com/onsi/ginkgo v1.10.1
+	github.com/onsi/gomega v1.7.0
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	github.com/operator-framework/operator-sdk v0.15.2
 	github.com/spf13/pflag v1.0.5

--- a/pkg/client/command_types.go
+++ b/pkg/client/command_types.go
@@ -39,8 +39,8 @@ package client
 import (
 	"encoding/json"
 	"errors"
+
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/uuid"
 )
 
 // CommandMessage represents the body of a command request to be sent
@@ -56,14 +56,14 @@ type CommandMessage struct {
 
 // NewCommandMessage provides a conventient shorthand for constructing
 // new CommandMessages
-func NewCommandMessage(command string, targetID string, args ...string) *CommandMessage {
-	return NewControlMessage(command, append([]string{targetID}, args...)...)
+func NewCommandMessage(command string, targetID string, id types.UID, args ...string) *CommandMessage {
+	return NewControlMessage(command, id, append([]string{targetID}, args...)...)
 }
 
 // NewControlMessage provides a convenient shorthand for constructing
 // new control CommandMessages, which do not include a targetID
-func NewControlMessage(command string, args ...string) *CommandMessage {
-	return &CommandMessage{ID: uuid.NewUUID(), Command: command, Args: args}
+func NewControlMessage(command string, id types.UID, args ...string) *CommandMessage {
+	return &CommandMessage{ID: id, Command: command, Args: args}
 }
 
 // ResponseStatus is a response code used by Container JFR to indiciate

--- a/pkg/controller/common/common_reconciler.go
+++ b/pkg/controller/common/common_reconciler.go
@@ -161,7 +161,9 @@ func (r *commonReconciler) IsClientConnected() bool {
 
 // CloseClient closes the underlying WebSocket connection to Container JFR
 func (r *commonReconciler) CloseClient() {
-	r.ContainerJfrClient.Close()
+	if r.ContainerJfrClient != nil {
+		r.ContainerJfrClient.Close()
+	}
 	r.ContainerJfrClient = nil
 }
 

--- a/pkg/controller/common/common_utils.go
+++ b/pkg/controller/common/common_utils.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2020 Red Hat, Inc.
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or data
+// (collectively the "Software"), free of charge and under any and all copyright
+// rights in the Software, and any and all patent rights owned or freely
+// licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger
+// Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+// one is included with the Software (each a "Larger Work" to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition:
+// The above copyright notice and either this complete permission notice or at
+// a minimum a reference to the UPL must be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package common
+
+import (
+	"io/ioutil"
+	"os"
+
+	jfrclient "github.com/rh-jmc-team/container-jfr-operator/pkg/client"
+)
+
+// ContainerJFRConnector provides a mechanism to connect to Container JFR
+type ContainerJFRConnector interface {
+	Connect(config *jfrclient.Config) (jfrclient.ContainerJfrClient, error)
+}
+
+// OSUtils is an abstraction on functionality that interacts with the operating system
+type OSUtils interface {
+	GetEnv(name string) string
+	GetFileContents(path string) ([]byte, error)
+}
+
+type defaultConnector struct{}
+
+func (c *defaultConnector) Connect(config *jfrclient.Config) (jfrclient.ContainerJfrClient, error) {
+	return jfrclient.Create(config)
+}
+
+type defaultOSUtils struct{}
+
+// GetEnv returns the value of the environment variable with the provided name. If no such
+// variable exists, the empty string is returned.
+func (o *defaultOSUtils) GetEnv(name string) string {
+	return os.Getenv(name)
+}
+
+// GetFileContents reads and returns the entire file contents specified by the path
+func (o *defaultOSUtils) GetFileContents(path string) ([]byte, error) {
+	return ioutil.ReadFile(path)
+}

--- a/pkg/controller/flightrecorder/flightrecorder_controller_test.go
+++ b/pkg/controller/flightrecorder/flightrecorder_controller_test.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2020 Red Hat, Inc.
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or data
+// (collectively the "Software"), free of charge and under any and all copyright
+// rights in the Software, and any and all patent rights owned or freely
+// licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger
+// Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+// one is included with the Software (each a "Larger Work" to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition:
+// The above copyright notice and either this complete permission notice or at
+// a minimum a reference to the UPL must be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package flightrecorder_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/gorilla/websocket"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	rhjmcv1alpha1 "github.com/rh-jmc-team/container-jfr-operator/pkg/apis/rhjmc/v1alpha1"
+	rhjmcv1alpha2 "github.com/rh-jmc-team/container-jfr-operator/pkg/apis/rhjmc/v1alpha2"
+	jfrclient "github.com/rh-jmc-team/container-jfr-operator/pkg/client"
+	"github.com/rh-jmc-team/container-jfr-operator/pkg/controller/common"
+	"github.com/rh-jmc-team/container-jfr-operator/pkg/controller/flightrecorder"
+)
+
+var _ = Describe("FlightRecorderController", func() {
+	var (
+		objs       []runtime.Object
+		messages   []wsMessage
+		server     *ghttp.Server
+		client     client.Client
+		controller *flightrecorder.ReconcileFlightRecorder
+	)
+
+	JustBeforeEach(func() {
+		s := scheme.Scheme
+
+		s.AddKnownTypes(rhjmcv1alpha1.SchemeGroupVersion, &rhjmcv1alpha1.ContainerJFR{},
+			&rhjmcv1alpha1.ContainerJFRList{})
+		s.AddKnownTypes(rhjmcv1alpha2.SchemeGroupVersion, &rhjmcv1alpha2.FlightRecorder{},
+			&rhjmcv1alpha2.FlightRecorderList{})
+
+		server = ghttp.NewServer()
+		clientURLResp := struct {
+			ClientURL string `json:"clientUrl"`
+		}{
+			getClientURL(server),
+		}
+		server.RouteToHandler("GET", "/api/v1/clienturl", ghttp.RespondWithJSONEncoded(http.StatusOK, clientURLResp))
+		server.RouteToHandler("GET", "/command", replayHandler(messages))
+		updateContainerJFRService(server, cjfrSvc)
+
+		client = fake.NewFakeClientWithScheme(s, objs...)
+		controller = &flightrecorder.ReconcileFlightRecorder{
+			Client: client,
+			Scheme: s,
+			Reconciler: common.NewReconciler(&common.ReconcilerConfig{
+				Client:    client,
+				Connector: &testConnector{},
+				OS:        &testOSUtils{},
+			}),
+		}
+	})
+
+	JustAfterEach(func() {
+		server.Close()
+	})
+
+	Describe("reconciling a request", func() {
+		Context("successfully updates FlightRecorder CR", func() {
+			BeforeEach(func() {
+				objs = []runtime.Object{
+					cjfr, fr, pod, cjfrSvc,
+				}
+				messages = []wsMessage{
+					{
+						expectedMsg: jfrclient.NewCommandMessage(
+							"list-event-types",
+							"1.2.3.4:8001",
+							types.UID("0")),
+						reply: &jfrclient.ResponseMessage{
+							ID:          types.UID("0"),
+							CommandName: "list-event-types",
+							Status:      jfrclient.ResponseStatusSuccess,
+							Payload: []rhjmcv1alpha2.EventInfo{
+								socketReadEvent,
+							},
+						},
+					},
+				}
+			})
+			It("should update event type list", func() {
+				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-pod", Namespace: "default"}}
+				result, err := controller.Reconcile(req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+
+				obj := &rhjmcv1alpha2.FlightRecorder{}
+				client.Get(context.Background(), req.NamespacedName, obj)
+				Expect(obj.Status.Events).To(Equal(messages[0].reply.Payload))
+			})
+		})
+	})
+})
+
+type wsMessage struct {
+	expectedMsg *jfrclient.CommandMessage
+	reply       *jfrclient.ResponseMessage
+}
+
+type testConnector struct{}
+
+func (c *testConnector) Connect(config *jfrclient.Config) (jfrclient.ContainerJfrClient, error) {
+	uidCount := 0
+	uidFunc := func() types.UID {
+		uid := strconv.Itoa(uidCount)
+		uidCount++
+		return types.UID(uid)
+	}
+
+	config.UIDProvider = uidFunc
+	return jfrclient.Create(config)
+}
+
+type testOSUtils struct{}
+
+func (o *testOSUtils) GetFileContents(path string) ([]byte, error) {
+	Expect(path).To(Equal("/var/run/secrets/kubernetes.io/serviceaccount/token"))
+	return []byte("myToken"), nil
+}
+
+func (o *testOSUtils) GetEnv(name string) string {
+	Expect(name).To(Equal("TLS_VERIFY"))
+	return "false"
+}
+
+func updateContainerJFRService(server *ghttp.Server, svc *corev1.Service) {
+	serverURL, err := url.Parse(server.URL())
+	Expect(err).ToNot(HaveOccurred())
+
+	svc.Spec.ClusterIP = serverURL.Hostname()
+	port, err := strconv.Atoi(serverURL.Port())
+	Expect(err).ToNot(HaveOccurred())
+	svc.Spec.Ports[0].Port = int32(port)
+}
+
+func replayHandler(messages []wsMessage) http.HandlerFunc {
+	return func(rw http.ResponseWriter, req *http.Request) {
+		upgrader := websocket.Upgrader{}
+
+		conn, err := upgrader.Upgrade(rw, req, nil)
+		Expect(err).ToNot(HaveOccurred())
+		defer conn.Close()
+
+		for _, msg := range messages {
+			in := &jfrclient.CommandMessage{}
+			err := conn.ReadJSON(in)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(in).To(Equal(msg.expectedMsg))
+			err = conn.WriteJSON(msg.reply)
+			Expect(err).ToNot(HaveOccurred())
+		}
+	}
+}
+
+func getClientURL(server *ghttp.Server) string {
+	return fmt.Sprintf("ws%s/command", strings.TrimPrefix(server.URL(), "http"))
+}

--- a/pkg/controller/flightrecorder/flightrecorder_resources_test.go
+++ b/pkg/controller/flightrecorder/flightrecorder_resources_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2020 Red Hat, Inc.
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or data
+// (collectively the "Software"), free of charge and under any and all copyright
+// rights in the Software, and any and all patent rights owned or freely
+// licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger
+// Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+// one is included with the Software (each a "Larger Work" to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition:
+// The above copyright notice and either this complete permission notice or at
+// a minimum a reference to the UPL must be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package flightrecorder_test
+
+import (
+	rhjmcv1alpha1 "github.com/rh-jmc-team/container-jfr-operator/pkg/apis/rhjmc/v1alpha1"
+	rhjmcv1alpha2 "github.com/rh-jmc-team/container-jfr-operator/pkg/apis/rhjmc/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	cjfr = &rhjmcv1alpha1.ContainerJFR{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "containerjfr",
+			Namespace: "default",
+		},
+		Spec: rhjmcv1alpha1.ContainerJFRSpec{
+			Minimal: false,
+		},
+	}
+	fr = &rhjmcv1alpha2.FlightRecorder{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+		Spec: rhjmcv1alpha2.FlightRecorderSpec{
+			RecordingSelector: metav1.AddLabelToSelector(&metav1.LabelSelector{}, rhjmcv1alpha2.RecordingLabel, "test-pod"),
+		},
+		Status: rhjmcv1alpha2.FlightRecorderStatus{
+			Target: &corev1.ObjectReference{
+				APIVersion: "v1",
+				Kind:       "Pod",
+				Name:       "test-pod",
+				Namespace:  "default",
+			},
+			Port: 8001,
+		},
+	}
+	pod = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+		Status: corev1.PodStatus{
+			PodIP: "1.2.3.4",
+		},
+	}
+	cjfrSvc = &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "containerjfr",
+			Namespace: "default",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "TBD",
+			Ports: []corev1.ServicePort{
+				{
+					Name: "export",
+					Port: -1,
+				},
+			},
+		},
+	}
+
+	socketReadEvent = rhjmcv1alpha2.EventInfo{
+		TypeID:      "jdk.socketRead",
+		Name:        "Socket Read",
+		Description: "Reading data from a socket",
+		Category:    []string{"Java Application"},
+		Options: map[string]rhjmcv1alpha2.OptionDescriptor{
+			"enabled": {
+				Name:         "Enabled",
+				Description:  "Record event",
+				DefaultValue: "false",
+			},
+			"stackTrace": {
+				Name:         "Stack Trace",
+				Description:  "Record stack traces",
+				DefaultValue: "false",
+			},
+			"threshold": {
+				Name:         "Threshold",
+				Description:  "Record event with duration above or equal to threshold",
+				DefaultValue: "0ns[ns]",
+			},
+		},
+	}
+)

--- a/pkg/controller/flightrecorder/flightrecorder_suite_test.go
+++ b/pkg/controller/flightrecorder/flightrecorder_suite_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2020 Red Hat, Inc.
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or data
+// (collectively the "Software"), free of charge and under any and all copyright
+// rights in the Software, and any and all patent rights owned or freely
+// licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger
+// Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+// one is included with the Software (each a "Larger Work" to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition:
+// The above copyright notice and either this complete permission notice or at
+// a minimum a reference to the UPL must be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package flightrecorder_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestFlightrecorder(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "FlightRecorder Suite")
+}


### PR DESCRIPTION
This PR adds unit tests for the FlightRecorder controller using Ginkgo & Gomega. They work using the controller-runtime fake client to simulate the Kubernetes API server. A simple Gomega/httptest server stands in for Container JFR by expecting messages and replying with specified replies. This server code will be refactored to a common test package once I add tests for the Recording controller.

There is also a fair bit of refactoring done here in order to make the code more testable. This includes things like converting structs to interfaces and adding constructor functions with optional parameters used by the tests to mock system/random behaviour.

The tests can be run with `go test ./pkg/controller/flightrecorder/`