### PR TITLE
Add/reorganize Makefile targets for running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ PREV_INDEX_VERSION ?= $(INDEX_VERSION)
 
 BUILDER ?= podman
 
+GINKGO ?= $(shell go env GOPATH)/bin/ginkgo
+
 .DEFAULT_GOAL := bundle
 
 .PHONY: generate
@@ -84,7 +86,19 @@ else
 endif
 
 .PHONY: test
-test: undeploy scorecard
+test: undeploy test-unit test-integration
+
+.PHONY: test-unit
+test-unit:
+# Run tests with Ginkgo CLI if available
+ifneq ("$(wildcard $(GINKGO))","")
+	"$(GINKGO)" -v ./...
+else
+	go test -v ./...
+endif
+
+.PHONY: test-integration
+test-integration: scorecard
 
 .PHONY: scorecard
 scorecard:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ and
 - [`operator-sdk`](https://github.com/operator-framework/operator-sdk) v0.15.2
 - [`opm`](https://github.com/operator-framework/operator-registry)
 - `podman`
+- `ginkgo` (Optional)
 
 ## Instructions
 Operator SDK requires the `GOROOT` environment variable to be set to the root
@@ -87,9 +88,13 @@ is handy for local development testing using ex. CodeReady Containers.
 - (optional) [crc](https://github.com/code-ready/crc)
 
 ## Instructions
-`make test` will run the automated tests. This requires an OpenShift 4 cluster
-to be available and logged in with your `oc` OpenShift Client. The recommended
-setup for development testing is CodeReady Containers (`crc`).
+`make test` will run all automated tests listed below. `make test-unit` will
+run only the operator's unit tests using `ginkgo` if installed, or `go test` if
+not. `make test-integration` and `make scorecard` are currently synonyms and
+will run only the Operator SDK's scorecard test suite. This requires an
+OpenShift 4 cluster to be available and logged in with your `oc` OpenShift
+Client. The recommended setup for development testing is CodeReady Containers
+(`crc`).
 
-Before the tests are run, all container-jfr and container-jfr-operator
+Before the scorecard tests are run, all container-jfr and container-jfr-operator
 resources will be deleted to ensure a clean slate.


### PR DESCRIPTION
This adds a Makefile target for running the unit tests. If the ginkgo binary is detected, it will run the tests with that, which has a bit nicer output. There is also a new target for running integration-tests, which is currently just the scorecard tests. Once we get some end-to-end tests, they could be added to this target as well.

I've also updated the README for this change.