### PR TITLE
Add tests for recording deletion

### DIFF
--- a/pkg/controller/recording/recording_controller.go
+++ b/pkg/controller/recording/recording_controller.go
@@ -201,6 +201,7 @@ func (r *ReconcileRecording) Reconcile(request reconcile.Request) (reconcile.Res
 			if err != nil {
 				log.Error(err, "failed to delete recording in Container JFR", "namespace", instance.Namespace,
 					"name", instance.Name)
+				return reconcile.Result{}, err
 			}
 
 			// Remove our finalizer only once our cleanup logic has succeeded

--- a/test/messages.go
+++ b/test/messages.go
@@ -135,6 +135,37 @@ func listSavedMessage(saved []jfrclient.SavedRecording) WsMessage {
 	}
 }
 
+func NewDeleteMessage() WsMessage {
+	return WsMessage{
+		ExpectedMsg: jfrclient.NewCommandMessage(
+			"delete",
+			"1.2.3.4:8001",
+			tmpUID,
+			"test-recording"),
+		Reply: &jfrclient.ResponseMessage{
+			ID:          tmpUID,
+			CommandName: "delete",
+			Status:      jfrclient.ResponseStatusSuccess,
+			Payload:     "",
+		},
+	}
+}
+
+func NewDeleteSavedMessage() WsMessage {
+	return WsMessage{
+		ExpectedMsg: jfrclient.NewControlMessage(
+			"delete-saved",
+			tmpUID,
+			"saved-test-recording.jfr"),
+		Reply: &jfrclient.ResponseMessage{
+			ID:          tmpUID,
+			CommandName: "delete-saved",
+			Status:      jfrclient.ResponseStatusSuccess,
+			Payload:     "",
+		},
+	}
+}
+
 func NewListEventTypesMessage() WsMessage {
 	return WsMessage{
 		ExpectedMsg: jfrclient.NewCommandMessage(

--- a/test/resources.go
+++ b/test/resources.go
@@ -121,11 +121,20 @@ func NewArchivedRecording() *rhjmcv1alpha2.Recording {
 	return rec
 }
 
+func NewDeletedArchivedRecording() *rhjmcv1alpha2.Recording {
+	rec := NewArchivedRecording()
+	delTime := metav1.Unix(0, 1598045501618*int64(time.Millisecond))
+	rec.DeletionTimestamp = &delTime
+	return rec
+}
+
 func newRecording(duration time.Duration, currentState *rhjmcv1alpha2.RecordingState,
 	requestedState *rhjmcv1alpha2.RecordingState, archive bool) *rhjmcv1alpha2.Recording {
+	finalizers := []string{}
 	status := rhjmcv1alpha2.RecordingStatus{}
 	if currentState != nil {
 		url := "http://path/to/test-recording.jfr"
+		finalizers = append(finalizers, "recording.finalizer.rhjmc.redhat.com")
 		status = rhjmcv1alpha2.RecordingStatus{
 			State:       currentState,
 			StartTime:   metav1.Unix(0, 1597090030341*int64(time.Millisecond)),
@@ -137,7 +146,7 @@ func newRecording(duration time.Duration, currentState *rhjmcv1alpha2.RecordingS
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "my-recording",
 			Namespace:  "default",
-			Finalizers: []string{"recording.finalizer.rhjmc.redhat.com"},
+			Finalizers: finalizers,
 		},
 		Spec: rhjmcv1alpha2.RecordingSpec{
 			Name: "test-recording",


### PR DESCRIPTION
This PR adds some additional tests that focus on deleted Recordings and how finalizers are used to perform cleanup. One fix in this PR is to return an error and requeue when the `delete` command fails.