### PR TITLE
Deploy Container JFR with TLS using service serving certificates

### DIFF
--- a/pkg/controller/flightrecorder/flightrecorder_controller.go
+++ b/pkg/controller/flightrecorder/flightrecorder_controller.go
@@ -67,8 +67,7 @@ func Add(mgr manager.Manager) error {
 func newReconciler(mgr manager.Manager) *ReconcileFlightRecorder {
 	return &ReconcileFlightRecorder{Client: mgr.GetClient(), Scheme: mgr.GetScheme(),
 		Reconciler: common.NewReconciler(&common.ReconcilerConfig{
-			Client:     mgr.GetClient(),
-			DisableTLS: true, // FIXME remove once TLS support is present in operator
+			Client: mgr.GetClient(),
 		}),
 	}
 }

--- a/pkg/controller/recording/recording_controller.go
+++ b/pkg/controller/recording/recording_controller.go
@@ -72,8 +72,7 @@ func Add(mgr manager.Manager) error {
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	return &ReconcileRecording{Scheme: mgr.GetScheme(), Client: mgr.GetClient(),
 		Reconciler: common.NewReconciler(&common.ReconcilerConfig{
-			Client:     mgr.GetClient(),
-			DisableTLS: true, // FIXME remove once TLS support is present in operator
+			Client: mgr.GetClient(),
 		}),
 	}
 }


### PR DESCRIPTION
This PR aims to support TLS in Container JFR when deployed in OpenShift from the operator. The idea is to use the default router wildcard certificate for the Container JFR route, but with TLS termination set to re-encrypt instead of edge. The internal service traffic is encrypted using a key-pair/cert created by the OpenShift service serving certificates mechanism [1]. The created certificate is signed by OpenShift's service CA, which is already trusted by the router. These keys/certs get converted from PEM format keys/certs into PKCS12 keystores/truststores using an init container and are passed to Container JFR using a mounted emptyDir volume [2].

This seems to work, except for enabling TLS for the remote JMX connection. After passing `-Djavax.net.debug=ssl,handshake` to Container JFR, I get the following error:
```
javax.net.ssl|ERROR|1C|RMI TCP Connection(16)-10.116.0.54|2020-09-18 20:33:23.111 GMT|TransportContext.java:318|Fatal (CERTIFICATE_UNKNOWN): Extended key usage does not permit use for TLS client authentication (
"throwable" : {
  sun.security.validator.ValidatorException: Extended key usage does not permit use for TLS client authentication
      at java.base/sun.security.validator.EndEntityChecker.checkTLSClient(EndEntityChecker.java:245)
      at java.base/sun.security.validator.EndEntityChecker.check(EndEntityChecker.java:146)
      at java.base/sun.security.validator.Validator.validate(Validator.java:277)
      at java.base/sun.security.ssl.X509TrustManagerImpl.validate(X509TrustManagerImpl.java:313)
      at java.base/sun.security.ssl.X509TrustManagerImpl.checkTrusted(X509TrustManagerImpl.java:222)
      at java.base/sun.security.ssl.X509TrustManagerImpl.checkClientTrusted(X509TrustManagerImpl.java:123)
      at java.base/sun.security.ssl.CertificateMessage$T13CertificateConsumer.checkClientCerts(CertificateMessage.java:1267)
      at java.base/sun.security.ssl.CertificateMessage$T13CertificateConsumer.onConsumeCertificate(CertificateMessage.java:1186)
      at java.base/sun.security.ssl.CertificateMessage$T13CertificateConsumer.consume(CertificateMessage.java:1163)
      at java.base/sun.security.ssl.SSLHandshake.consume(SSLHandshake.java:392)
      at java.base/sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:444)
      at java.base/sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:422)
      at java.base/sun.security.ssl.TransportContext.dispatch(TransportContext.java:183)
      at java.base/sun.security.ssl.SSLTransport.decode(SSLTransport.java:164)
      at java.base/sun.security.ssl.SSLSocketImpl.decode(SSLSocketImpl.java:1144)
      at java.base/sun.security.ssl.SSLSocketImpl.readHandshakeRecord(SSLSocketImpl.java:1055)
      at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:395)
      at java.base/sun.security.ssl.SSLSocketImpl.ensureNegotiated(SSLSocketImpl.java:709)
      at java.base/sun.security.ssl.SSLSocketImpl$AppInputStream.read(SSLSocketImpl.java:792)
      at java.base/java.io.BufferedInputStream.fill(BufferedInputStream.java:252)
      at java.base/java.io.BufferedInputStream.read(BufferedInputStream.java:271)
      at java.base/java.io.DataInputStream.readInt(DataInputStream.java:392)
      at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:716)
      at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:677)
      at java.base/java.security.AccessController.doPrivileged(Native Method)
      at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:676)
      at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
      at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
      at java.base/java.lang.Thread.run(Thread.java:834)} 
```
I then verified that these service serving certificates do not support TLS client authentication. [3][4] If we don't set `com.sun.management.jmxremote.ssl.need.client.auth=true`, then the JMX communication works, but this is not ideal. I'm marking this PR as a draft for now while we explore solutions to allow mutual TLS authentication for JMX connections. One obvious solution is to create a self signed cert just for client authentication, but there may be better solutions.

[1] https://docs.openshift.com/container-platform/4.5/security/certificates/service-serving-certificate.html
[2] https://developers.redhat.com/blog/2017/11/22/dynamically-creating-java-keystores-openshift/
[3] https://github.com/openshift/origin/issues/10085
[4] https://github.com/openshift/service-ca-operator/issues/62