### PR TITLE
Update Grafana container to 7.2.1

### DIFF
--- a/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
+++ b/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
@@ -278,7 +278,7 @@ func GenPasswd(length int) string {
 func NewGrafanaContainer(cr *rhjmcv1alpha1.ContainerJFR) corev1.Container {
 	return corev1.Container{
 		Name:  cr.Name + "-grafana",
-		Image: "docker.io/grafana/grafana:6.4.4",
+		Image: "docker.io/grafana/grafana:7.2.1",
 		Ports: []corev1.ContainerPort{
 			{
 				ContainerPort: 3000,


### PR DESCRIPTION
See also https://github.com/rh-jmc-team/container-jfr/pull/292 for a quicker smoketest of the new version. It seems to be fully compatible with our dashboard definition and the jfr-datasource with no apparent regressions or other adjustments needed.