### PR TITLE
Restrict jfr-datasource to pod-internal traffic

### DIFF
--- a/pkg/controller/containerjfr/containerjfr_controller.go
+++ b/pkg/controller/containerjfr/containerjfr_controller.go
@@ -201,14 +201,7 @@ func (r *ReconcileContainerJFR) Reconcile(request reconcile.Request) (reconcile.
 			return reconcile.Result{}, err
 		}
 		serviceSpecs.GrafanaAddress = fmt.Sprintf("%s://%s", protocol, url)
-
-		// TODO Restrict jfr-datasource to localhost
-		datasourceSvc := resources.NewJfrDatasourceService(instance)
-		url, err = r.createService(context.Background(), instance, datasourceSvc, nil, nil)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-		serviceSpecs.DatasourceAddress = fmt.Sprintf("http://%s", url)
+		serviceSpecs.DatasourceAddress = "http://127.0.0.1:8080"
 
 		// check for existing minimal deployment and delete if found
 		deployment := resources.NewDeploymentForCR(instance, serviceSpecs, nil)

--- a/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
+++ b/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
@@ -529,32 +529,6 @@ func NewGrafanaService(cr *rhjmcv1alpha1.ContainerJFR) *corev1.Service {
 	}
 }
 
-func NewJfrDatasourceService(cr *rhjmcv1alpha1.ContainerJFR) *corev1.Service {
-	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Name + "-jfr-datasource",
-			Namespace: cr.Namespace,
-			Labels: map[string]string{
-				"app":       cr.Name,
-				"component": "jfr-datasource",
-			},
-		},
-		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeClusterIP,
-			Selector: map[string]string{
-				"app": cr.Name,
-			},
-			Ports: []corev1.ServicePort{
-				{
-					Name:       "8080-tcp",
-					Port:       8080,
-					TargetPort: intstr.IntOrString{IntVal: 8080},
-				},
-			},
-		},
-	}
-}
-
 func NewJmxSecretForCR(cr *rhjmcv1alpha1.ContainerJFR) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
+++ b/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
@@ -423,7 +423,7 @@ const datasourceHost = "127.0.0.1"
 const datasourcePort = "8080"
 
 // DatasourceURL contains the fixed URL to jfr-datasource's web server
-const DatasourceURL = "http://" + datasourceHost + datasourcePort
+const DatasourceURL = "http://" + datasourceHost + ":" + datasourcePort
 
 func NewJfrDatasourceContainer(cr *rhjmcv1alpha1.ContainerJFR) corev1.Container {
 	return corev1.Container{

--- a/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
+++ b/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
@@ -423,7 +423,7 @@ func NewGrafanaContainer(cr *rhjmcv1alpha1.ContainerJFR, tls *TLSConfig) corev1.
 func NewJfrDatasourceContainer(cr *rhjmcv1alpha1.ContainerJFR) corev1.Container {
 	return corev1.Container{
 		Name:  cr.Name + "-jfr-datasource",
-		Image: "quay.io/rh-jmc-team/jfr-datasource:0.0.1",
+		Image: "quay.io/rh-jmc-team/jfr-datasource:0.0.2",
 		Ports: []corev1.ContainerPort{
 			{
 				ContainerPort: 8080,

--- a/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
+++ b/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
@@ -50,10 +50,9 @@ import (
 )
 
 type ServiceSpecs struct {
-	CoreAddress       string
-	CommandAddress    string
-	GrafanaAddress    string
-	DatasourceAddress string
+	CoreAddress    string
+	CommandAddress string
+	GrafanaAddress string
 }
 
 // TLSConfig contains TLS-related information useful when creating other objects
@@ -222,7 +221,7 @@ func NewCoreContainer(cr *rhjmcv1alpha1.ContainerJFR, specs *ServiceSpecs, tls *
 		},
 		{
 			Name:  "GRAFANA_DATASOURCE_URL",
-			Value: specs.DatasourceAddress,
+			Value: DatasourceURL,
 		},
 		{
 			// FIXME remove once JMX auth support is present in operator
@@ -420,6 +419,12 @@ func NewGrafanaContainer(cr *rhjmcv1alpha1.ContainerJFR, tls *TLSConfig) corev1.
 	}
 }
 
+const datasourceHost = "127.0.0.1"
+const datasourcePort = "8080"
+
+// DatasourceURL contains the fixed URL to jfr-datasource's web server
+const DatasourceURL = "http://" + datasourceHost + datasourcePort
+
 func NewJfrDatasourceContainer(cr *rhjmcv1alpha1.ContainerJFR) corev1.Container {
 	return corev1.Container{
 		Name:  cr.Name + "-jfr-datasource",
@@ -432,14 +437,14 @@ func NewJfrDatasourceContainer(cr *rhjmcv1alpha1.ContainerJFR) corev1.Container 
 		Env: []corev1.EnvVar{
 			{
 				Name:  "LISTEN_HOST",
-				Value: "127.0.0.1",
+				Value: datasourceHost,
 			},
 		},
 		// Can't use HTTP probe since the port is not exposed over the network
 		LivenessProbe: &corev1.Probe{
 			Handler: corev1.Handler{
 				Exec: &corev1.ExecAction{
-					Command: []string{"curl", "--fail", "http://127.0.0.1:8080"},
+					Command: []string{"curl", "--fail", DatasourceURL},
 				},
 			},
 		},

--- a/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
+++ b/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
@@ -429,12 +429,17 @@ func NewJfrDatasourceContainer(cr *rhjmcv1alpha1.ContainerJFR) corev1.Container 
 				ContainerPort: 8080,
 			},
 		},
-		Env: []corev1.EnvVar{},
+		Env: []corev1.EnvVar{
+			{
+				Name:  "LISTEN_HOST",
+				Value: "127.0.0.1",
+			},
+		},
+		// Can't use HTTP probe since the port is not exposed over the network
 		LivenessProbe: &corev1.Probe{
 			Handler: corev1.Handler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Port: intstr.IntOrString{IntVal: 8080},
-					Path: "/",
+				Exec: &corev1.ExecAction{
+					Command: []string{"curl", "--fail", "http://127.0.0.1:8080"},
 				},
 			},
 		},

--- a/pkg/controller/grafana/grafana_controller.go
+++ b/pkg/controller/grafana/grafana_controller.go
@@ -50,6 +50,7 @@ import (
 	"time"
 
 	"github.com/rh-jmc-team/container-jfr-operator/pkg/controller/common"
+	resources "github.com/rh-jmc-team/container-jfr-operator/pkg/controller/containerjfr/resource_definitions"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -240,7 +241,7 @@ func (r *ReconcileGrafana) configureGrafanaDatasource(httpClient *http.Client, s
 	datasource := GrafanaDatasource{
 		Name:      "jfr-datasource",
 		Type:      "grafana-simple-json-datasource",
-		URL:       "http://127.0.0.1:8080",
+		URL:       resources.DatasourceURL,
 		Access:    "proxy",
 		BasicAuth: false,
 		IsDefault: true,

--- a/pkg/controller/grafana/grafana_controller.go
+++ b/pkg/controller/grafana/grafana_controller.go
@@ -237,24 +237,10 @@ func (r *ReconcileGrafana) configureGrafanaDatasource(httpClient *http.Client, s
 		}
 	}
 
-	logger.Info("Checking for jfr-datasource service")
-	services := corev1.ServiceList{}
-	err = r.client.List(context.Background(), &services, client.InNamespace(svc.Namespace), client.MatchingLabels{"component": "jfr-datasource"})
-	if err != nil {
-		return err
-	}
-	if len(services.Items) != 1 {
-		return errors.NewInternalError(goerrors.New(fmt.Sprintf("Expected one jfr-datasource service, found %d", len(services.Items))))
-	}
-	if len(services.Items[0].Spec.Ports) != 1 {
-		return errors.NewInternalError(goerrors.New(fmt.Sprintf("Expected service %s to have one Port, but got %d", services.Items[0].Name, len(services.Items[0].Spec.Ports))))
-	}
-	datasourceURL := fmt.Sprintf("http://%s:%d", services.Items[0].Spec.ClusterIP, services.Items[0].Spec.Ports[0].Port)
-
 	datasource := GrafanaDatasource{
 		Name:      "jfr-datasource",
 		Type:      "grafana-simple-json-datasource",
-		URL:       datasourceURL,
+		URL:       "http://127.0.0.1:8080",
 		Access:    "proxy",
 		BasicAuth: false,
 		IsDefault: true,


### PR DESCRIPTION
This PR depends on https://github.com/rh-jmc-team/jfr-datasource/pull/54. Since communication to/from jfr-datasource is only between containers in the same pod, we can restrict it to loopback traffic only. This is particularly important since this communication is unencrypted.

The fix is fairly straightforward, aside from the liveness probe. HTTP/TCP probes appear to require the port be accessible outside of the pod. I was able to use a command probe instead where the `curl` command is done within the container itself.

Fixes: #117 