### PR TITLE
Use different subpaths within volume for recordings and templates

### DIFF
--- a/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
+++ b/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
@@ -242,10 +242,12 @@ func NewCoreContainer(cr *rhjmcv1beta1.ContainerJFR, specs *ServiceSpecs, tls *T
 		{
 			Name:      cr.Name,
 			MountPath: "flightrecordings",
+			SubPath:   "flightrecordings",
 		},
 		{
 			Name:      cr.Name,
 			MountPath: "templates",
+			SubPath:   "templates",
 		},
 	}
 


### PR DESCRIPTION
I noticed when archiving a recording, that the recording also ended up in the templates directory. This is because we use the same mounted volume for both recordings and templates, and by default it's the volume's root directory that is mounted. This fix specifies the `SubPath` property for each mount, which will mount different directories within the volume.