### PR TITLE
Add check to make sure cert-manager is available before deploying

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,11 @@ remove_catalog:
 
 .PHONY: deploy
 deploy: undeploy
+ifeq ($(shell oc api-versions | grep -c '^cert-manager.io/v1$$'), 0)
+ifneq ($(DISABLE_SERVICE_TLS), true)
+	$(error cert-manager is not installed)
+endif
+endif
 	oc create -f deploy/service_account.yaml
 	oc create -f deploy/role.yaml
 	oc create -f deploy/role_binding.yaml

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ remove_catalog:
 deploy: undeploy
 ifeq ($(shell oc api-versions | grep -c '^cert-manager.io/v1$$'), 0)
 ifneq ($(DISABLE_SERVICE_TLS), true)
-	$(error cert-manager is not installed)
+	$(error cert-manager is not installed, install using "make cert-manager" or disable TLS for services by setting DISABLE_SERVICE_TLS to true)
 endif
 endif
 	oc create -f deploy/service_account.yaml


### PR DESCRIPTION
Fixes #127 
This will ensure that the operator is never deployed using OC without cert-manager. I am not sure if there are other ways that the operator might be used, in which case it could still fail without cert-manager?