### PR TITLE
Update expected platform strategy package

### DIFF
--- a/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
+++ b/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
@@ -181,7 +181,7 @@ func NewCoreContainer(cr *rhjmcv1beta1.ContainerJFR, specs *ServiceSpecs, tls *T
 	envs := []corev1.EnvVar{
 		{
 			Name:  "CONTAINER_JFR_PLATFORM",
-			Value: "com.redhat.rhjmc.containerjfr.platform.openshift.OpenShiftPlatformStrategy",
+			Value: "com.redhat.rhjmc.containerjfr.platform.internal.OpenShiftPlatformStrategy",
 		},
 		{
 			Name:  "CONTAINER_JFR_SSL_PROXIED",
@@ -294,7 +294,7 @@ func NewCoreContainer(cr *rhjmcv1beta1.ContainerJFR, specs *ServiceSpecs, tls *T
 		// Use HTTPS for liveness probe
 		livenessProbeScheme = corev1.URISchemeHTTPS
 	}
-	imageTag := "quay.io/rh-jmc-team/container-jfr:1.0.0-BETA1"
+	imageTag := "quay.io/rh-jmc-team/container-jfr:1.0.0-BETA4"
 	if cr.Spec.Minimal {
 		imageTag += "-minimal"
 		envs = append(envs, corev1.EnvVar{


### PR DESCRIPTION
The class `OpenShiftPlatformStrategy` was moved in a recent upstream patch (rh-jmc-team/container-jfr#391), so this adjusts the environment variable that explicitly specifies this strategy should be selected. #393 is a backport of #391 for v1 and also moves the Strategy to the same location, so this applies for either version.