### PR TITLE
Update to 1.0.0-BETA5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE_STREAM ?= quay.io/rh-jmc-team/container-jfr-operator
-IMAGE_VERSION ?= 0.5.0
+IMAGE_VERSION ?= 1.0.0-BETA5
 IMAGE_TAG ?= $(IMAGE_STREAM):$(IMAGE_VERSION)
 
 BUNDLE_STREAM ?= $(IMAGE_STREAM)-bundle

--- a/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
+++ b/pkg/controller/containerjfr/resource_definitions/resource_definitions.go
@@ -328,7 +328,7 @@ func NewCoreContainer(cr *rhjmcv1beta1.ContainerJFR, specs *ServiceSpecs, tls *T
 		// Use HTTPS for liveness probe
 		livenessProbeScheme = corev1.URISchemeHTTPS
 	}
-	imageTag := "quay.io/rh-jmc-team/container-jfr:1.0.0-BETA4"
+	imageTag := "quay.io/rh-jmc-team/container-jfr:1.0.0-BETA5"
 	if cr.Spec.Minimal {
 		imageTag += "-minimal"
 		envs = append(envs, corev1.EnvVar{


### PR DESCRIPTION
This updates the Container JFR image and operator version to 1.0.0-BETA5. I'll tag this commit as well. This should provide a stable option for users while we make changes leading to the 1.0 release. The catalog source will still pull in the old 0.5.0 version, but it should work. We don't want to release a new bundle until we're certain the v1beta1 API is settled.