### PR TITLE
Associate ClusterRoleBinding with namespaced operator using label

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ undeploy: undeploy_sample_app undeploy_sample_app2 undeploy_sample_app_quarkus
 	- oc delete -f deploy/service_account.yaml
 	- oc delete -f deploy/role.yaml
 	- oc delete -f deploy/role_binding.yaml
-	- oc delete clusterrolebinding -l app=containerjfr
+	- oc delete clusterrolebinding -l operator-name=container-jfr-operator,operator-namespace=$(NAMESPACE)
 
 .PHONY: cert_manager
 cert_manager:

--- a/deploy/cluster_role_binding.yaml
+++ b/deploy/cluster_role_binding.yaml
@@ -4,7 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   generateName: container-jfr-operator-
   labels:
-    app: containerjfr
+    operator-name: container-jfr-operator
+    operator-namespace: REPLACE_NAMESPACE
 subjects:
 - kind: ServiceAccount
   name: container-jfr-operator


### PR DESCRIPTION
This adds a namespace label to the ClusterRoleBinding, so when the Makefile deletes it during `undeploy`, it will only remove the binding associated with the current namespace.