### PR TITLE
Fix Makefile test targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,14 +167,12 @@ OperatorHub will eventually receive.
 - (optional) [crc](https://github.com/code-ready/crc)
 
 ## Instructions
-`make test-unit` will run unit tests using ginkgo if installed, or go test if
+`make test-envtest` will run controller tests using ginkgo if installed, or go test if
 not, requiring no cluster connection.
 
-`make test-integration` will run integration tests, including `envtest` and the
-Operator SDK's scorecard test suite. This requires an OpenShift 4 cluster to be
-available and logged in with your `oc` OpenShift Client. The recommended setup
-for development testing is CodeReady Containers (`crc`). `make test-envtest`
-and `make test-scorecard` can be used to run these separately.
+`make test-scorecard` will run the Operator SDK's scorecard test suite. This requires a
+Kubernetes or OpenShift cluster to be available and logged in with your `kubectl` or `oc`
+client. The recommended setup for development testing is CodeReady Containers (`crc`).
 
 Before the scorecard tests are run, all container-jfr and container-jfr-operator
 resources will be deleted to ensure a clean slate.


### PR DESCRIPTION
Currently, `make test` is failing because the unit test suite now depends on envtest. Because of this, it no longer makes sense to have a separate `test-unit` target. The unit tests should eventually make use the envtest environment, bringing them closer to integration tests. For now, I've just left them as `test-envtest`. Scorecard is the only integration-test target, so I've reduced the test targets to just `test-envtest` and `test-scorecard`, with `test` running both.

Since the scorecard tests require a running cluster and are currently failing, I've removed them as a prerequisite for the `oci-build` target.