### PR TITLE
Deploy to arbitrary namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ CERT_MANAGER_VERSION ?= 1.1.0
 CERT_MANAGER_MANIFEST ?= \
 	https://github.com/jetstack/cert-manager/releases/download/v$(CERT_MANAGER_VERSION)/cert-manager.yaml
 
+DEPLOY_NAMESPACE ?= container-jfr-operator-system
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -83,14 +85,14 @@ uninstall: manifests kustomize
 .PHONY: deploy
 deploy: manifests kustomize
 	pushd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG) && popd
-	$(KUSTOMIZE) build config/default | $(CLUSTER_CLIENT) apply -f -
+	$(KUSTOMIZE) build config/default | sed 's/container-jfr-operator-system/$(DEPLOY_NAMESPACE)/' | $(CLUSTER_CLIENT) apply -f -
 
 # UnDeploy controller from the configured Kubernetes cluster in ~/.kube/config
 .PHONY: undeploy
 undeploy:
 	- $(CLUSTER_CLIENT) delete recording --all
 	- $(CLUSTER_CLIENT) delete -f config/samples/rhjmc_v1beta1_containerjfr.yaml
-	- $(KUSTOMIZE) build config/default | $(CLUSTER_CLIENT) delete -f -
+	- $(KUSTOMIZE) build config/default | sed 's/container-jfr-operator-system/$(DEPLOY_NAMESPACE)/' | $(CLUSTER_CLIENT) delete -f -
 
 # Generate manifests e.g. CRD, RBAC etc.
 .PHONY: manifests

--- a/README.md
+++ b/README.md
@@ -139,10 +139,15 @@ required to prepare the cluster for deploying the operator, using `oc` or
 `kubectl` on whichever OpenShift cluster is configured with the local client.
 `make uninstall` destroys the CRDs and undoes the setup.
 
-`make deploy` will deploy the operator in the current namespace.
+`make deploy` will deploy the operator in the default namespace
+(`container-jfr-operator-system`). `make DEPLOY_NAMESPACE=foo-namespace deploy`
+can be used to deploy to an arbitrary namespace named `foo-namespace`. For
+a convenient shorthand, use `make DEPLOY_NAMESPACE=$(oc project -q) deploy` to
+deploy to the currently active OpenShift project namespace.
+`make undeploy` will likewise remove the operator, and also uses the
+`DEPLOY_NAMESPACE` variable.
 This also respects the `IMAGE_TAG` environment variable, so that different
 versions of the operator can be easily deployed.
-`make undeploy` will likewise remove the operator from the current namespace.
 
 `make run` can be used to run the operator controller manager as a process on
 your local development machine and observing/interacting with your cluster.


### PR DESCRIPTION
This allows the user to (un)deploy the Operator to arbitrary namespaces, not only `container-jfr-operator-system`. This can be done like so:

`make DEPLOY_NAMESPACE=some_namespace deploy` (or `undeploy`)

Deployment to the current namespace would then look like `make DEPLOY_NAMESPACE=$(oc project -q) deploy`. I could also set the default value for `DEPLOY_NAMESPACE` to the current namespace, but I thought it might be better to require this to be explicit.

I tried to use the `config/default/kustomization.yaml`'s `namespace` property for this purpose with `kustomize`, but this ended up modifying the file in an unexpected way and changing it beyond simply replacing the `namespace` value. So I have simply used a piped `sed`  here, which is similar to what we did before the `1.x` migration. I leave the default `container-jfr-operator-system` namespace value intact however, rather than replacing it with something like `REPLACE_NAMESPACE`, so that the default value is something reasonable looking when `make bundle` is run.

This doesn't seem to work for the `default` namespace - I see an error that the operator pod cannot be started because it has `runAsNonRoot` but will be run as root. It does deploy successfully in other namespaces, however. I'm looking into what the reason is here.

Fixes #172