### PR TITLE
Add check in deploy_bundle to make sure cert manager is installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ remove_cert_manager:
 
 .PHONY: check_cert_manager
 check_cert_manager:
-       @api_versions=$$(kubectl api-versions) &&\
+	@api_versions=$$(kubectl api-versions) &&\
        if [ $$(echo "$${api_versions}" | grep -c '^cert-manager.io/v1$$') -eq 0 ]; then if [ "$${DISABLE_SERVICE_TLS}" != "true" ]; then\
                        echo 'cert-manager is not installed, install using "make cert_manager" or disable TLS for services by setting DISABLE_SERVICE_TLS to true' >&2\
                        && exit 1;\

--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,11 @@ bundle-build:
 
 .PHONY: deploy_bundle
 deploy_bundle: undeploy_bundle
+ifeq ($(shell kubectl api-versions | grep -c '^cert-manager.io/v1$$'), 0)
+ifneq ($(DISABLE_SERVICE_TLS), true)
+	$(error cert-manager is not installed, install using "make cert-manager" or disable TLS for services by setting DISABLE_SERVICE_TLS to true)
+endif
+endif
 	operator-sdk run bundle $(IMAGE_NAMESPACE)/$(OPERATOR_NAME)-bundle:$(IMAGE_VERSION)
 ifeq ($(DISABLE_SERVICE_TLS), true)
 	@echo "Disabling TLS for in-cluster communication between Services"

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ print_deploy_config: predeploy
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 .PHONY: deploy
-deploy: manifests kustomize predeploy
+deploy: check_cert_manager manifests kustomize predeploy
 	$(KUSTOMIZE) build config/default | $(CLUSTER_CLIENT) apply -f -
 ifeq ($(DISABLE_SERVICE_TLS), true)
 	@echo "Disabling TLS for in-cluster communication between Services"
@@ -140,7 +140,13 @@ cert_manager: remove_cert_manager
 remove_cert_manager:
 	- $(CLUSTER_CLIENT) delete -f $(CERT_MANAGER_MANIFEST)
 
-
+.PHONY: check_cert_manager
+check_cert_manager:
+ifeq ($(shell kubectl api-versions | grep -c '^cert-manager.io/v1$$'), 0)
+ifneq ($(DISABLE_SERVICE_TLS), true)
+	$(error cert-manager is not installed, install using "make cert_manager" or disable TLS for services by setting DISABLE_SERVICE_TLS to true)
+endif
+endif
 
 # Download controller-gen locally if necessary
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
@@ -180,12 +186,7 @@ bundle-build:
 	$(IMAGE_BUILDER) build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: deploy_bundle
-deploy_bundle: undeploy_bundle
-ifeq ($(shell kubectl api-versions | grep -c '^cert-manager.io/v1$$'), 0)
-ifneq ($(DISABLE_SERVICE_TLS), true)
-	$(error cert-manager is not installed, install using "make cert-manager" or disable TLS for services by setting DISABLE_SERVICE_TLS to true)
-endif
-endif
+deploy_bundle: check_cert_manager undeploy_bundle
 	operator-sdk run bundle $(IMAGE_NAMESPACE)/$(OPERATOR_NAME)-bundle:$(IMAGE_VERSION)
 ifeq ($(DISABLE_SERVICE_TLS), true)
 	@echo "Disabling TLS for in-cluster communication between Services"

--- a/Makefile
+++ b/Makefile
@@ -142,11 +142,12 @@ remove_cert_manager:
 
 .PHONY: check_cert_manager
 check_cert_manager:
-ifeq ($(shell kubectl api-versions | grep -c '^cert-manager.io/v1$$'), 0)
-ifneq ($(DISABLE_SERVICE_TLS), true)
-	$(error cert-manager is not installed, install using "make cert_manager" or disable TLS for services by setting DISABLE_SERVICE_TLS to true)
-endif
-endif
+       @api_versions=$$(kubectl api-versions) &&\
+       if [ $$(echo "$${api_versions}" | grep -c '^cert-manager.io/v1$$') -eq 0 ]; then if [ "$${DISABLE_SERVICE_TLS}" != "true" ]; then\
+                       echo 'cert-manager is not installed, install using "make cert_manager" or disable TLS for services by setting DISABLE_SERVICE_TLS to true' >&2\
+                       && exit 1;\
+               fi;\
+       fi
 
 # Download controller-gen locally if necessary
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen


### PR DESCRIPTION
This check existed before in the deploy target but got lost in the operator sdk upgrade. I added it to the deploy_bundle given it's the command I have been using, but it probably makes sense to add it to deploy as well.