### PR TITLE
Fix DISABLE_SERVICE_TLS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,9 @@ print_deploy_config: predeploy
 .PHONY: deploy
 deploy: manifests kustomize predeploy
 	$(KUSTOMIZE) build config/default | $(CLUSTER_CLIENT) apply -f -
+ifeq ($(DISABLE_SERVICE_TLS), true)
+	$(CLUSTER_CLIENT) -n $(DEPLOY_NAMESPACE) set env deployment/container-jfr-operator-controller-manager DISABLE_SERVICE_TLS=true
+endif
 
 # UnDeploy controller from the configured Kubernetes cluster in ~/.kube/config
 .PHONY: undeploy
@@ -178,6 +181,9 @@ bundle-build:
 .PHONY: deploy_bundle
 deploy_bundle: undeploy_bundle
 	operator-sdk run bundle $(IMAGE_NAMESPACE)/$(OPERATOR_NAME)-bundle:$(IMAGE_VERSION)
+ifeq ($(DISABLE_SERVICE_TLS), true)
+	$(CLUSTER_CLIENT) set env deployment/container-jfr-operator-controller-manager DISABLE_SERVICE_TLS=true
+endif
 
 .PHONY: undeploy_bundle
 undeploy_bundle:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ endif
 GINKGO ?= $(shell go env GOPATH)/bin/ginkgo
 GO_TEST ?= go test
 ifneq ("$(wildcard $(GINKGO))","")
-GO_TEST="$(GINKGO)"
+GO_TEST="$(GINKGO)" -cover -outputdir=.
 endif
 
 all: manager

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test-envtest: generate fmt vet manifests
 	mkdir -p $(ENVTEST_ASSETS_DIR)
 	test -f $(ENVTEST_ASSETS_DIR)/setup-envtest.sh || curl -sSLo $(ENVTEST_ASSETS_DIR)/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh
-	source $(ENVTEST_ASSETS_DIR)/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); $(GO_TEST) -v ./... -coverprofile cover.out
+	source $(ENVTEST_ASSETS_DIR)/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); $(GO_TEST) -v -coverprofile cover.out ./...
 
 .PHONY: test-scorecard
 test-scorecard: destroy_containerjfr_cr undeploy uninstall

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ ifeq ($(DISABLE_SERVICE_TLS), true)
 		echo -e "Expected 1 Subscription, found $${#}:\n$${@}" >&2; \
 		exit 1; \
 	fi; \
-	$(CLUSTER_CLIENT) -n $(DEPLOY_NAMESPACE) patch --type=merge -p '{"spec":{"config":{"env":[{"name":"DISABLE_SERVICE_TLS","value":"true"}]}}}' "$${1}"
+	$(CLUSTER_CLIENT) patch --type=merge -p '{"spec":{"config":{"env":[{"name":"DISABLE_SERVICE_TLS","value":"true"}]}}}' "$${1}"
 endif
 
 .PHONY: undeploy_bundle

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ API to manage [JDK Flight Recordings](https://openjdk.java.net/jeps/328).
 Once deployed, the `containerjfr` instance can be accessed via web browser
 at the URL provided by:
 ```
-kubectl get pod -l kind=containerjfr -o jsonpath='https://{$.items[0].metadata.annotations.redhat\.com/containerJfrUrl} '
+kubectl get pod -l kind=containerjfr -o jsonpath='{$.items[0].metadata.annotations.redhat\.com/containerJfrUrl}'
 ```
 The Grafana credentials can be obtained with:
 ```shell

--- a/README.md
+++ b/README.md
@@ -142,8 +142,9 @@ required to prepare the cluster for deploying the operator, using `oc` or
 `make deploy` will deploy the operator in the default namespace
 (`container-jfr-operator-system`). `make DEPLOY_NAMESPACE=foo-namespace deploy`
 can be used to deploy to an arbitrary namespace named `foo-namespace`. For
-a convenient shorthand, use `make DEPLOY_NAMESPACE=$(oc project -q) deploy` to
-deploy to the currently active OpenShift project namespace.
+a convenient shorthand, use
+`make DEPLOY_NAMESPACE=$(kubectl config view --minify -o 'jsonpath={.contexts[0].context.namespace}') deploy`
+to deploy to the currently active OpenShift project namespace.
 `make undeploy` will likewise remove the operator, and also uses the
 `DEPLOY_NAMESPACE` variable.
 This also respects the `IMAGE_TAG` environment variable, so that different

--- a/controllers/common/resource_definitions/resource_definitions.go
+++ b/controllers/common/resource_definitions/resource_definitions.go
@@ -119,7 +119,7 @@ func NewDeploymentForCR(cr *rhjmcv1beta1.ContainerJFR, specs *ServiceSpecs, tls 
 				"app.kubernetes.io/name": "container-jfr",
 			},
 			Annotations: map[string]string{
-				"redhat.com/containerJfrUrl":   specs.CoreURL.String(), // TODO Fix README
+				"redhat.com/containerJfrUrl":   specs.CoreURL.String(),
 				"app.openshift.io/connects-to": "container-jfr-operator",
 			},
 		},

--- a/controllers/common/resource_definitions/resource_definitions.go
+++ b/controllers/common/resource_definitions/resource_definitions.go
@@ -39,6 +39,7 @@ package resource_definitions
 import (
 	"fmt"
 	"math/rand"
+	"net/url"
 	"time"
 
 	consolev1 "github.com/openshift/api/console/v1"
@@ -51,9 +52,9 @@ import (
 )
 
 type ServiceSpecs struct {
-	CoreHostname    string
-	CommandHostname string
-	GrafanaURL      string
+	CoreURL    *url.URL
+	CommandURL *url.URL
+	GrafanaURL *url.URL
 }
 
 // TLSConfig contains TLS-related information useful when creating other objects
@@ -118,7 +119,7 @@ func NewDeploymentForCR(cr *rhjmcv1beta1.ContainerJFR, specs *ServiceSpecs, tls 
 				"app.kubernetes.io/name": "container-jfr",
 			},
 			Annotations: map[string]string{
-				"redhat.com/containerJfrUrl":   specs.CoreHostname,
+				"redhat.com/containerJfrUrl":   specs.CoreURL.String(), // TODO Fix README
 				"app.openshift.io/connects-to": "container-jfr-operator",
 			},
 		},
@@ -138,7 +139,7 @@ func NewDeploymentForCR(cr *rhjmcv1beta1.ContainerJFR, specs *ServiceSpecs, tls 
 						"kind": "containerjfr",
 					},
 					Annotations: map[string]string{
-						"redhat.com/containerJfrUrl": specs.CoreHostname,
+						"redhat.com/containerJfrUrl": specs.CoreURL.String(),
 					},
 				},
 				Spec: *NewPodForCR(cr, specs, tls),
@@ -180,15 +181,19 @@ func NewPodForCR(cr *rhjmcv1beta1.ContainerJFR, specs *ServiceSpecs, tls *TLSCon
 				},
 			},
 		}
-		grafanaSecretVolume := corev1.Volume{
-			Name: "grafana-tls-secret",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: tls.GrafanaSecret,
+		volumes = append(volumes, secretVolume)
+
+		if !cr.Spec.Minimal {
+			grafanaSecretVolume := corev1.Volume{
+				Name: "grafana-tls-secret",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: tls.GrafanaSecret,
+					},
 				},
-			},
+			}
+			volumes = append(volumes, grafanaSecretVolume)
 		}
-		volumes = append(volumes, secretVolume, grafanaSecretVolume)
 
 		customVolumes := []corev1.Volume{}
 		for _, secret := range cr.Spec.TrustedCertSecrets {
@@ -231,11 +236,11 @@ func NewCoreContainer(cr *rhjmcv1beta1.ContainerJFR, specs *ServiceSpecs, tls *T
 		},
 		{
 			Name:  "CONTAINER_JFR_EXT_WEB_PORT",
-			Value: "443",
+			Value: getPort(specs.CoreURL),
 		},
 		{
 			Name:  "CONTAINER_JFR_WEB_HOST",
-			Value: specs.CoreHostname,
+			Value: specs.CoreURL.Hostname(),
 		},
 		{
 			Name:  "CONTAINER_JFR_LISTEN_PORT",
@@ -243,19 +248,11 @@ func NewCoreContainer(cr *rhjmcv1beta1.ContainerJFR, specs *ServiceSpecs, tls *T
 		},
 		{
 			Name:  "CONTAINER_JFR_EXT_LISTEN_PORT",
-			Value: "443",
+			Value: getPort(specs.CommandURL),
 		},
 		{
 			Name:  "CONTAINER_JFR_LISTEN_HOST",
-			Value: specs.CommandHostname,
-		},
-		{
-			Name:  "GRAFANA_DASHBOARD_URL",
-			Value: specs.GrafanaURL,
-		},
-		{
-			Name:  "GRAFANA_DATASOURCE_URL",
-			Value: DatasourceURL,
+			Value: specs.CommandURL.Hostname(),
 		},
 		{
 			Name:  "CONTAINER_JFR_TEMPLATE_PATH",
@@ -283,6 +280,20 @@ func NewCoreContainer(cr *rhjmcv1beta1.ContainerJFR, specs *ServiceSpecs, tls *T
 			MountPath: "templates",
 			SubPath:   "templates",
 		},
+	}
+
+	if !cr.Spec.Minimal {
+		grafanaVars := []corev1.EnvVar{
+			{
+				Name:  "GRAFANA_DASHBOARD_URL",
+				Value: specs.GrafanaURL.String(),
+			},
+			{
+				Name:  "GRAFANA_DATASOURCE_URL",
+				Value: DatasourceURL,
+			},
+		}
+		envs = append(envs, grafanaVars...)
 	}
 
 	livenessProbeScheme := corev1.URISchemeHTTP
@@ -401,7 +412,12 @@ func GenPasswd(length int) string {
 }
 
 func NewGrafanaContainer(cr *rhjmcv1beta1.ContainerJFR, tls *TLSConfig) corev1.Container {
-	envs := []corev1.EnvVar{}
+	envs := []corev1.EnvVar{
+		{
+			Name:  "JFR_DATASOURCE_URL",
+			Value: DatasourceURL,
+		},
+	}
 	mounts := []corev1.VolumeMount{}
 
 	// Configure TLS key/cert if enabled
@@ -419,10 +435,6 @@ func NewGrafanaContainer(cr *rhjmcv1beta1.ContainerJFR, tls *TLSConfig) corev1.C
 			{
 				Name:  "GF_SERVER_CERT_FILE",
 				Value: fmt.Sprintf("/var/run/secrets/rhjmc.redhat.com/%s/%s", tls.GrafanaSecret, corev1.TLSCertKey),
-			},
-			{
-				Name:  "JFR_DATASOURCE_URL",
-				Value: DatasourceURL,
 			},
 		}
 
@@ -643,4 +655,17 @@ func NewConsoleLink(cr *rhjmcv1beta1.ContainerJFR, url string) *consolev1.Consol
 			},
 		},
 	}
+}
+
+func getPort(url *url.URL) string {
+	// Return port if already defined in URL
+	port := url.Port()
+	if len(port) > 0 {
+		return port
+	}
+	// Otherwise use default HTTP(S) ports
+	if url.Scheme == "https" {
+		return "443"
+	}
+	return "80"
 }

--- a/controllers/containerjfr_controller.go
+++ b/controllers/containerjfr_controller.go
@@ -449,13 +449,6 @@ func getProtocol(tlsConfig *openshiftv1.TLSConfig) string {
 	return "https"
 }
 
-func getPort(tlsConfig *openshiftv1.TLSConfig) string {
-	if tlsConfig == nil {
-		return "80"
-	}
-	return "443"
-}
-
 func requeueIfIngressNotReady(log logr.Logger, err error) (reconcile.Result, error) {
 	if err == ErrIngressNotReady {
 		log.Info(err.Error())

--- a/controllers/containerjfr_controller.go
+++ b/controllers/containerjfr_controller.go
@@ -39,6 +39,9 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -154,7 +157,6 @@ func (r *ContainerJFRReconciler) Reconcile(ctx context.Context, request ctrl.Req
 	}
 
 	// Set up TLS using cert-manager, if available
-	protocol := "http"
 	var tlsConfig *resources.TLSConfig
 	var routeTLS *openshiftv1.TLSConfig
 	if r.IsCertManagerEnabled() {
@@ -176,7 +178,6 @@ func (r *ContainerJFRReconciler) Reconcile(ctx context.Context, request ctrl.Req
 			Termination:              openshiftv1.TLSTerminationReencrypt,
 			DestinationCACertificate: string(caCert),
 		}
-		protocol = "https"
 	}
 
 	serviceSpecs := &resources.ServiceSpecs{}
@@ -184,13 +185,13 @@ func (r *ContainerJFRReconciler) Reconcile(ctx context.Context, request ctrl.Req
 		grafanaSvc := resources.NewGrafanaService(instance)
 		url, err := r.createService(context.Background(), instance, grafanaSvc, &grafanaSvc.Spec.Ports[0], routeTLS)
 		if err != nil {
-			return reconcile.Result{}, err
+			return requeueIfIngressNotReady(err)
 		}
-		serviceSpecs.GrafanaURL = fmt.Sprintf("%s://%s", protocol, url)
+		serviceSpecs.GrafanaURL = url
 
 		// check for existing minimal deployment and delete if found
-		deployment := resources.NewDeploymentForCR(instance, serviceSpecs, nil)
-		err = r.Client.Get(context.Background(), types.NamespacedName{Name: deployment.Name, Namespace: deployment.Namespace}, deployment)
+		deployment := &appsv1.Deployment{}
+		err = r.Client.Get(context.Background(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, deployment)
 		if err == nil && len(deployment.Spec.Template.Spec.Containers) == 1 {
 			reqLogger.Info("Deleting existing minimal deployment")
 			err = r.Client.Delete(context.Background(), deployment)
@@ -225,8 +226,8 @@ func (r *ContainerJFRReconciler) Reconcile(ctx context.Context, request ctrl.Req
 			}
 		}
 
-		deployment := resources.NewDeploymentForCR(instance, serviceSpecs, nil)
-		err = r.Client.Get(context.Background(), types.NamespacedName{Name: deployment.Name, Namespace: deployment.Namespace}, deployment)
+		deployment := &appsv1.Deployment{}
+		err = r.Client.Get(context.Background(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, deployment)
 		if err == nil && len(deployment.Spec.Template.Spec.Containers) > 1 {
 			reqLogger.Info("Deleting existing non-minimal deployment")
 			err = r.Client.Delete(context.Background(), deployment)
@@ -240,16 +241,16 @@ func (r *ContainerJFRReconciler) Reconcile(ctx context.Context, request ctrl.Req
 	exporterSvc := resources.NewExporterService(instance)
 	url, err := r.createService(context.Background(), instance, exporterSvc, &exporterSvc.Spec.Ports[0], routeTLS)
 	if err != nil {
-		return reconcile.Result{}, err
+		return requeueIfIngressNotReady(err)
 	}
-	serviceSpecs.CoreHostname = url
+	serviceSpecs.CoreURL = url
 
 	cmdChanSvc := resources.NewCommandChannelService(instance)
 	url, err = r.createService(context.Background(), instance, cmdChanSvc, &cmdChanSvc.Spec.Ports[0], routeTLS)
 	if err != nil {
-		return reconcile.Result{}, err
+		return requeueIfIngressNotReady(err)
 	}
-	serviceSpecs.CommandHostname = url
+	serviceSpecs.CommandURL = url
 
 	deployment := resources.NewDeploymentForCR(instance, serviceSpecs, tlsConfig)
 	if err := controllerutil.SetControllerReference(instance, deployment, r.Scheme); err != nil {
@@ -282,7 +283,7 @@ func (r *ContainerJFRReconciler) Reconcile(ctx context.Context, request ctrl.Req
 		return reconcile.Result{}, err
 	}
 	if len(links) == 0 {
-		link := resources.NewConsoleLink(instance, "https://"+serviceSpecs.CoreHostname)
+		link := resources.NewConsoleLink(instance, serviceSpecs.CoreURL.String())
 		if err = r.Client.Create(context.Background(), link); err != nil {
 			reqLogger.Error(err, "Could not create ConsoleLink")
 			return reconcile.Result{}, err
@@ -314,12 +315,12 @@ func (r *ContainerJFRReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *ContainerJFRReconciler) createService(ctx context.Context, controller *rhjmcv1beta1.ContainerJFR, svc *corev1.Service, exposePort *corev1.ServicePort,
-	tlsConfig *openshiftv1.TLSConfig) (string, error) {
+	tlsConfig *openshiftv1.TLSConfig) (*url.URL, error) {
 	if err := controllerutil.SetControllerReference(controller, svc, r.Scheme); err != nil {
-		return "", err
+		return nil, err
 	}
 	if err := r.createObjectIfNotExists(context.Background(), types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}, &corev1.Service{}, svc); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	// Use edge termination by default
@@ -334,19 +335,28 @@ func (r *ContainerJFRReconciler) createService(ctx context.Context, controller *
 	}
 
 	if err := r.Client.Get(context.Background(), types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}, svc); err != nil {
-		return "", err
+		return nil, err
 	}
 	if svc.Spec.ClusterIP == "" {
-		return "", errors.NewInternalError(goerrors.New(fmt.Sprintf("Expected service %s to have ClusterIP, but got empty string", svc.Name)))
+		return nil, errors.NewInternalError(goerrors.New(fmt.Sprintf("Expected service %s to have ClusterIP, but got empty string", svc.Name)))
 	}
 	if len(svc.Spec.Ports) != 1 {
-		return "", errors.NewInternalError(goerrors.New(fmt.Sprintf("Expected service %s to have one Port, but got %d", svc.Name, len(svc.Spec.Ports))))
+		return nil, errors.NewInternalError(goerrors.New(fmt.Sprintf("Expected service %s to have one Port, but got %d", svc.Name, len(svc.Spec.Ports))))
 	}
-	return fmt.Sprintf("%s:%d", svc.Spec.ClusterIP, svc.Spec.Ports[0].Port), nil
+	// TODO can we repurpose this for exposing services on k8s where Status.LoadBalancer.IP is filled in?
+	// https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+	return &url.URL{
+		Scheme: getProtocol(tlsConfig),
+		Host:   net.JoinHostPort(svc.Spec.ClusterIP, strconv.Itoa(int(svc.Spec.Ports[0].Port))),
+	}, nil
 }
 
+// ErrIngressNotReady is returned when Kubernetes has not yet exposed our services
+// so that they may be accessed outside of the cluster
+var ErrIngressNotReady = goerrors.New("Ingress configuration not yet available")
+
 func (r *ContainerJFRReconciler) createRouteForService(controller *rhjmcv1beta1.ContainerJFR, svc *corev1.Service, exposePort corev1.ServicePort,
-	tlsConfig *openshiftv1.TLSConfig) (string, error) {
+	tlsConfig *openshiftv1.TLSConfig) (*url.URL, error) {
 	logger := r.Log.WithValues("Request.Namespace", svc.Namespace, "Name", svc.Name, "Kind", fmt.Sprintf("%T", &openshiftv1.Route{}))
 	route := &openshiftv1.Route{
 		ObjectMeta: metav1.ObjectMeta{
@@ -363,7 +373,7 @@ func (r *ContainerJFRReconciler) createRouteForService(controller *rhjmcv1beta1.
 		},
 	}
 	if err := controllerutil.SetControllerReference(controller, route, r.Scheme); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	found := &openshiftv1.Route{}
@@ -372,21 +382,24 @@ func (r *ContainerJFRReconciler) createRouteForService(controller *rhjmcv1beta1.
 		logger.Info("Not found")
 		if err := r.Client.Create(context.Background(), route); err != nil {
 			logger.Error(err, "Could not be created")
-			return "", err
+			return nil, err
 		}
 		logger.Info("Created")
 		found = route
 	} else if err != nil {
 		logger.Error(err, "Could not be read")
-		return "", err
+		return nil, err
 	}
 
 	logger.Info("Route created", "Service.Status", fmt.Sprintf("%#v", found.Status))
 	if len(found.Status.Ingress) < 1 {
-		return "", errors.NewTooManyRequestsError("Ingress configuration not yet available")
+		return nil, ErrIngressNotReady
 	}
 
-	return found.Status.Ingress[0].Host, nil
+	return &url.URL{
+		Scheme: getProtocol(tlsConfig),
+		Host:   found.Status.Ingress[0].Host,
+	}, nil
 }
 
 func (r *ContainerJFRReconciler) createObjectIfNotExists(ctx context.Context, ns types.NamespacedName, found client.Object, toCreate client.Object) error {
@@ -447,4 +460,26 @@ func (r *ContainerJFRReconciler) deleteConsoleLinks(ctx context.Context, cr *rhj
 		return reconcile.Result{}, err
 	}
 	return reconcile.Result{}, nil
+}
+
+func getProtocol(tlsConfig *openshiftv1.TLSConfig) string {
+	if tlsConfig == nil {
+		return "http"
+	}
+	return "https"
+}
+
+func getPort(tlsConfig *openshiftv1.TLSConfig) string {
+	if tlsConfig == nil {
+		return "80"
+	}
+	return "443"
+}
+
+func requeueIfIngressNotReady(err error) (reconcile.Result, error) {
+	if err == ErrIngressNotReady {
+		log.Info(err.Error())
+		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+	return reconcile.Result{}, err
 }

--- a/controllers/containerjfr_controller_test.go
+++ b/controllers/containerjfr_controller_test.go
@@ -38,6 +38,7 @@ package controllers_test
 
 import (
 	"context"
+	"net/url"
 	"time"
 
 	certv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
@@ -70,6 +71,7 @@ var _ = Describe("ContainerjfrController", func() {
 		objs       []runtime.Object
 		client     ctrlclient.Client
 		controller *controllers.ContainerJFRReconciler
+		tls        bool
 	)
 
 	JustBeforeEach(func() {
@@ -82,12 +84,17 @@ var _ = Describe("ContainerjfrController", func() {
 			Client:        client,
 			Scheme:        s,
 			Log:           logger,
-			ReconcilerTLS: test.NewTestReconcilerTLS(client),
+			ReconcilerTLS: test.NewTestReconcilerTLS(client, tls),
 		}
+	})
+
+	BeforeEach(func() {
+		tls = true
 	})
 
 	AfterEach(func() {
 		objs = nil
+		tls = false
 	})
 
 	Describe("reconciling a request", func() {
@@ -101,17 +108,17 @@ var _ = Describe("ContainerjfrController", func() {
 				expectCertificates(client, controller)
 			})
 			It("should create routes", func() {
-				expectRoutes(client, controller, false)
+				expectRoutes(client, controller, false, tls)
 			})
 			It("should create persistent volume claim and set owner", func() {
-				expectPVC(client, controller, test.NewDefaultPVC(), false)
+				expectPVC(client, controller, test.NewDefaultPVC(), false, tls)
 			})
 			It("should create Grafana secret and set owner", func() {
 				secret := &corev1.Secret{}
 				err := client.Get(context.Background(), types.NamespacedName{Name: "containerjfr-grafana-basic", Namespace: "default"}, secret)
 				Expect(kerrors.IsNotFound(err)).To(BeTrue())
 
-				reconcileContainerJFRFully(client, controller, false)
+				reconcileContainerJFRFully(client, controller, false, tls)
 
 				err = client.Get(context.Background(), types.NamespacedName{Name: "containerjfr-grafana-basic", Namespace: "default"}, secret)
 				Expect(err).ToNot(HaveOccurred())
@@ -122,24 +129,24 @@ var _ = Describe("ContainerjfrController", func() {
 				Expect(secret.StringData["GF_SECURITY_ADMIN_USER"]).To(Equal(expectedSecret.StringData["GF_SECURITY_ADMIN_USER"]))
 			})
 			It("should create JMX secret and set owner", func() {
-				expectJMXSecret(client, controller, false)
+				expectJMXSecret(client, controller, false, tls)
 			})
 			It("should create Grafana service and set owner", func() {
 				service := &corev1.Service{}
 				err := client.Get(context.Background(), types.NamespacedName{Name: "containerjfr-grafana", Namespace: "default"}, service)
 				Expect(kerrors.IsNotFound(err)).To(BeTrue())
 
-				reconcileContainerJFRFully(client, controller, false)
+				reconcileContainerJFRFully(client, controller, false, tls)
 				checkGrafanaService(client)
 			})
 			It("should create exporter service and set owner", func() {
-				expectExporterService(client, controller, false)
+				expectExporterService(client, controller, false, tls)
 			})
 			It("should create command channel service and set owner", func() {
-				expectCommandChannel(client, controller, false)
+				expectCommandChannel(client, controller, false, tls)
 			})
 			It("should create deployment and set owner", func() {
-				expectDeployment(client, controller, false)
+				expectDeployment(client, controller, false, tls)
 			})
 		})
 		Context("succesfully creates required resources for minimal deployment", func() {
@@ -152,22 +159,22 @@ var _ = Describe("ContainerjfrController", func() {
 				expectCertificates(client, controller)
 			})
 			It("should create routes", func() {
-				expectRoutes(client, controller, true)
+				expectRoutes(client, controller, true, tls)
 			})
 			It("should create persistent volume claim and set owner", func() {
-				expectPVC(client, controller, test.NewDefaultPVC(), true)
+				expectPVC(client, controller, test.NewDefaultPVC(), true, tls)
 			})
 			It("should create JMX secret and set owner", func() {
-				expectJMXSecret(client, controller, true)
+				expectJMXSecret(client, controller, true, tls)
 			})
 			It("should create exporter service and set owner", func() {
-				expectExporterService(client, controller, true)
+				expectExporterService(client, controller, true, tls)
 			})
 			It("should create command channel service and set owner", func() {
-				expectCommandChannel(client, controller, true)
+				expectCommandChannel(client, controller, true, tls)
 			})
 			It("should create deployment and set owner", func() {
-				expectDeployment(client, controller, true)
+				expectDeployment(client, controller, true, tls)
 			})
 		})
 		Context("after containerjfr reconciled successfully", func() {
@@ -177,7 +184,7 @@ var _ = Describe("ContainerjfrController", func() {
 				}
 			})
 			It("should be idempotent", func() {
-				expectIdempotence(client, controller, false)
+				expectIdempotence(client, controller, false, tls)
 			})
 		})
 		Context("After a minimal containerjfr reconciled successfully", func() {
@@ -187,7 +194,7 @@ var _ = Describe("ContainerjfrController", func() {
 				}
 			})
 			It("should be idempotent", func() {
-				expectIdempotence(client, controller, true)
+				expectIdempotence(client, controller, true, tls)
 			})
 		})
 		Context("ContainerJFR does not exist", func() {
@@ -205,7 +212,7 @@ var _ = Describe("ContainerjfrController", func() {
 				}
 			})
 			JustBeforeEach(func() {
-				reconcileContainerJFRFully(client, controller, true)
+				reconcileContainerJFRFully(client, controller, true, tls)
 
 				cjfr := &rhjmcv1beta1.ContainerJFR{}
 				err := client.Get(context.Background(), types.NamespacedName{Name: "containerjfr", Namespace: "default"}, cjfr)
@@ -216,17 +223,19 @@ var _ = Describe("ContainerjfrController", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "containerjfr", Namespace: "default"}}
-				_, err = controller.Reconcile(context.Background(), req)
-				Expect(err).To(HaveOccurred())
-				ingressConfig(client, controller, req, false)
-				_, err = controller.Reconcile(context.Background(), req)
+				result, err := controller.Reconcile(context.Background(), req)
+				Expect(result).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
 				Expect(err).ToNot(HaveOccurred())
+				ingressConfig(client, controller, req, false, tls)
+				result, err = controller.Reconcile(context.Background(), req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
 			})
 			It("should create grafana resources", func() {
 				checkGrafanaService(client)
 			})
 			It("should configure deployment appropriately", func() {
-				checkDeployment(client, false)
+				checkDeployment(client, false, tls)
 			})
 		})
 		Context("Switching from a non-minimal to a minimal deployment", func() {
@@ -236,7 +245,7 @@ var _ = Describe("ContainerjfrController", func() {
 				}
 			})
 			JustBeforeEach(func() {
-				reconcileContainerJFRFully(client, controller, false)
+				reconcileContainerJFRFully(client, controller, false, tls)
 
 				cjfr := &rhjmcv1beta1.ContainerJFR{}
 				err := client.Get(context.Background(), types.NamespacedName{Name: "containerjfr", Namespace: "default"}, cjfr)
@@ -260,7 +269,7 @@ var _ = Describe("ContainerjfrController", func() {
 				Expect(kerrors.IsNotFound(err)).To(BeTrue())
 			})
 			It("should configure deployment appropriately", func() {
-				checkDeployment(client, true)
+				checkDeployment(client, true, tls)
 			})
 		})
 		Context("Container jfr has list of certificate secrets", func() {
@@ -270,18 +279,18 @@ var _ = Describe("ContainerjfrController", func() {
 				}
 			})
 			It("Should add volumes and volumeMounts to deployment", func() {
-				reconcileContainerJFRFully(client, controller, false)
+				reconcileContainerJFRFully(client, controller, false, tls)
 				deployment := &appsv1.Deployment{}
 				err := client.Get(context.Background(), types.NamespacedName{Name: "containerjfr", Namespace: "default"}, deployment)
 				Expect(err).ToNot(HaveOccurred())
 
 				volumes := deployment.Spec.Template.Spec.Volumes
 				expectedVolumes := test.NewVolumesWithSecrets()
-				Expect(&volumes).To(Equal(expectedVolumes))
+				Expect(volumes).To(Equal(expectedVolumes))
 
 				volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
 				expectedVolumeMounts := test.NewVolumeMountsWithSecrets()
-				Expect(&volumeMounts).To(Equal(expectedVolumeMounts))
+				Expect(volumeMounts).To(Equal(expectedVolumeMounts))
 			})
 		})
 		Context("Adding a certificate to the TrustedCertSecrets list", func() {
@@ -291,7 +300,7 @@ var _ = Describe("ContainerjfrController", func() {
 				}
 			})
 			JustBeforeEach(func() {
-				reconcileContainerJFRFully(client, controller, false)
+				reconcileContainerJFRFully(client, controller, false, tls)
 			})
 			It("Should update the corresponding deployment", func() {
 				// Get ContainerJFR CR after reconciling
@@ -315,11 +324,11 @@ var _ = Describe("ContainerjfrController", func() {
 
 				volumes := deployment.Spec.Template.Spec.Volumes
 				expectedVolumes := test.NewVolumesWithSecrets()
-				Expect(&volumes).To(Equal(expectedVolumes))
+				Expect(volumes).To(Equal(expectedVolumes))
 
 				volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
 				expectedVolumeMounts := test.NewVolumeMountsWithSecrets()
-				Expect(&volumeMounts).To(Equal(expectedVolumeMounts))
+				Expect(volumeMounts).To(Equal(expectedVolumeMounts))
 			})
 		})
 		Context("with custom PVC spec overriding all defaults", func() {
@@ -329,7 +338,7 @@ var _ = Describe("ContainerjfrController", func() {
 				}
 			})
 			It("should create the PVC with requested spec", func() {
-				expectPVC(client, controller, test.NewCustomPVC(), false)
+				expectPVC(client, controller, test.NewCustomPVC(), false, tls)
 			})
 		})
 		Context("with custom PVC spec overriding some defaults", func() {
@@ -339,7 +348,7 @@ var _ = Describe("ContainerjfrController", func() {
 				}
 			})
 			It("should create the PVC with requested spec", func() {
-				expectPVC(client, controller, test.NewCustomPVCSomeDefault(), false)
+				expectPVC(client, controller, test.NewCustomPVCSomeDefault(), false, tls)
 			})
 		})
 		Context("with custom PVC config with no spec", func() {
@@ -349,7 +358,7 @@ var _ = Describe("ContainerjfrController", func() {
 				}
 			})
 			It("should create the PVC with requested label", func() {
-				expectPVC(client, controller, test.NewDefaultPVCWithLabel(), false)
+				expectPVC(client, controller, test.NewDefaultPVCWithLabel(), false, tls)
 			})
 		})
 		Context("on OpenShift", func() {
@@ -359,7 +368,7 @@ var _ = Describe("ContainerjfrController", func() {
 				}
 			})
 			JustBeforeEach(func() {
-				reconcileContainerJFRFully(client, controller, false)
+				reconcileContainerJFRFully(client, controller, false, tls)
 			})
 			It("should create ConsoleLink", func() {
 				links := &consolev1.ConsoleLinkList{}
@@ -373,7 +382,7 @@ var _ = Describe("ContainerjfrController", func() {
 				Expect(links.Items).To(HaveLen(1))
 				link := links.Items[0]
 				Expect(link.Spec.Text).To(Equal("Container JDK Flight Recorder"))
-				Expect(link.Spec.Href).To(Equal("https://test"))
+				Expect(link.Spec.Href).To(Equal("https://containerjfr.example.com"))
 				// Should be added to the NamespaceDashboard for only the current namespace
 				Expect(link.Spec.Location).To(Equal(consolev1.NamespaceDashboard))
 				Expect(link.Spec.NamespaceDashboard.Namespaces).To(Equal([]string{"default"}))
@@ -421,6 +430,27 @@ var _ = Describe("ContainerjfrController", func() {
 				})
 			})
 		})
+		Context("with service TLS disabled", func() {
+			BeforeEach(func() {
+				objs = []runtime.Object{
+					test.NewContainerJFR(),
+				}
+				tls = false
+			})
+			It("should create deployment and set owner", func() {
+				expectDeployment(client, controller, false, tls)
+			})
+			It("should not create certificates", func() {
+				certs := &certv1.CertificateList{}
+				client.List(context.Background(), certs, &ctrlclient.ListOptions{
+					Namespace: "default",
+				})
+				Expect(certs.Items).To(BeEmpty())
+			})
+			It("should create routes with edge TLS termination", func() {
+				expectRoutes(client, controller, false, tls)
+			})
+		})
 	})
 })
 
@@ -431,25 +461,26 @@ func newFakeSecret(name string) *corev1.Secret {
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
-			corev1.TLSCertKey: nil,
+			corev1.TLSCertKey: []byte(name + "-bytes"),
 		},
 	}
 }
 
 func newFakeServiceSpecs(minimal bool) resource_definitions.ServiceSpecs {
-	grafanaUrl := "https://test"
-	if minimal {
-		grafanaUrl = ""
+	protocol := "https"
+	var grafanaUrl *url.URL
+	if !minimal {
+		grafanaUrl = &url.URL{Scheme: protocol, Host: "containerjfr-grafana.example.com"}
 	}
 	return resource_definitions.ServiceSpecs{
-		CoreHostname:    "test",
-		CommandHostname: "test",
-		GrafanaURL:      grafanaUrl,
+		CoreURL:    &url.URL{Scheme: protocol, Host: "containerjfr.example.com"},
+		CommandURL: &url.URL{Scheme: protocol, Host: "containerjfr-command.example.com"},
+		GrafanaURL: grafanaUrl,
 	}
 }
 
-func newFakeTLSConfig() resource_definitions.TLSConfig {
-	return resource_definitions.TLSConfig{
+func newFakeTLSConfig() *resource_definitions.TLSConfig {
+	return &resource_definitions.TLSConfig{
 		ContainerJFRSecret: "containerjfr-tls",
 		GrafanaSecret:      "containerjfr-grafana-tls",
 		KeystorePassSecret: "containerjfr-keystore",
@@ -481,7 +512,7 @@ func initializeSecrets(client ctrlclient.Client) {
 	}
 }
 
-func ingressConfig(client ctrlclient.Client, controller *controllers.ContainerJFRReconciler, req reconcile.Request, minimal bool) {
+func ingressConfig(client ctrlclient.Client, controller *controllers.ContainerJFRReconciler, req reconcile.Request, minimal bool, tls bool) {
 	routes := []string{"containerjfr", "containerjfr-command"}
 	if !minimal {
 		routes = append([]string{"containerjfr-grafana"}, routes...)
@@ -490,8 +521,18 @@ func ingressConfig(client ctrlclient.Client, controller *controllers.ContainerJF
 		route := &openshiftv1.Route{}
 		err := client.Get(context.Background(), types.NamespacedName{Name: routeName, Namespace: "default"}, route)
 		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the TLS termination policy
+		Expect(route.Spec.TLS).ToNot(BeNil())
+		if tls {
+			Expect(route.Spec.TLS.Termination).To(Equal(openshiftv1.TLSTerminationReencrypt))
+			Expect(route.Spec.TLS.DestinationCACertificate).To(Equal("containerjfr-ca-bytes"))
+		} else {
+			Expect(route.Spec.TLS.Termination).To(Equal(openshiftv1.TLSTerminationEdge))
+			Expect(route.Spec.TLS.InsecureEdgeTerminationPolicy).To(Equal(openshiftv1.InsecureEdgeTerminationPolicyRedirect))
+		}
 		route.Status.Ingress = append(route.Status.Ingress, openshiftv1.RouteIngress{
-			Host: "test",
+			Host: routeName + ".example.com",
 		})
 		err = client.Status().Update(context.Background(), route)
 		Expect(err).ToNot(HaveOccurred())
@@ -499,19 +540,23 @@ func ingressConfig(client ctrlclient.Client, controller *controllers.ContainerJF
 	}
 }
 
-func reconcileContainerJFRFully(client ctrlclient.Client, controller *controllers.ContainerJFRReconciler, minimal bool) {
+func reconcileContainerJFRFully(client ctrlclient.Client, controller *controllers.ContainerJFRReconciler, minimal bool, tls bool) {
 	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "containerjfr", Namespace: "default"}}
 	result, err := controller.Reconcile(context.Background(), req)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(result).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
 
 	// Update certificate status
-	makeCertificatesReady(client)
-	initializeSecrets(client)
+	if tls {
+		makeCertificatesReady(client)
+		initializeSecrets(client)
+	}
 
 	// Add ingress config to routes
 	result, err = controller.Reconcile(context.Background(), req)
-	ingressConfig(client, controller, req, minimal)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(result).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
+	ingressConfig(client, controller, req, minimal, tls)
 
 	result, err = controller.Reconcile(context.Background(), req)
 	Expect(err).ToNot(HaveOccurred())
@@ -541,29 +586,31 @@ func expectCertificates(client ctrlclient.Client, controller *controllers.Contai
 	}
 }
 
-func expectRoutes(client ctrlclient.Client, controller *controllers.ContainerJFRReconciler, minimal bool) {
+func expectRoutes(client ctrlclient.Client, controller *controllers.ContainerJFRReconciler, minimal bool, tls bool) {
 	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "containerjfr", Namespace: "default"}}
 	result, err := controller.Reconcile(context.Background(), req)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(result).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
 
 	// Update certificate status
-	makeCertificatesReady(client)
-	initializeSecrets(client)
+	if tls {
+		makeCertificatesReady(client)
+		initializeSecrets(client)
+	}
 
 	// Check for routes, ingress configuration needs to be added as each
 	// one is created so that they all reconcile successfully
 	result, err = controller.Reconcile(context.Background(), req)
-	ingressConfig(client, controller, req, minimal)
+	ingressConfig(client, controller, req, minimal, tls)
 }
 
 func expectPVC(client ctrlclient.Client, controller *controllers.ContainerJFRReconciler,
-	expectedPvc *corev1.PersistentVolumeClaim, minimal bool) {
+	expectedPvc *corev1.PersistentVolumeClaim, minimal bool, tls bool) {
 	pvc := &corev1.PersistentVolumeClaim{}
 	err := client.Get(context.Background(), types.NamespacedName{Name: "containerjfr", Namespace: "default"}, pvc)
 	Expect(kerrors.IsNotFound(err)).To(BeTrue())
 
-	reconcileContainerJFRFully(client, controller, minimal)
+	reconcileContainerJFRFully(client, controller, minimal, tls)
 
 	err = client.Get(context.Background(), types.NamespacedName{Name: "containerjfr", Namespace: "default"}, pvc)
 	Expect(err).ToNot(HaveOccurred())
@@ -578,12 +625,12 @@ func expectPVC(client ctrlclient.Client, controller *controllers.ContainerJFRRec
 	Expect(pvcStorage.Equal(expectedPvcStorage)).To(BeTrue())
 }
 
-func expectJMXSecret(client ctrlclient.Client, controller *controllers.ContainerJFRReconciler, minimal bool) {
+func expectJMXSecret(client ctrlclient.Client, controller *controllers.ContainerJFRReconciler, minimal bool, tls bool) {
 	secret := &corev1.Secret{}
 	err := client.Get(context.Background(), types.NamespacedName{Name: "containerjfr-jmx-auth", Namespace: "default"}, secret)
 	Expect(kerrors.IsNotFound(err)).To(BeTrue())
 
-	reconcileContainerJFRFully(client, controller, minimal)
+	reconcileContainerJFRFully(client, controller, minimal, tls)
 
 	err = client.Get(context.Background(), types.NamespacedName{Name: "containerjfr-jmx-auth", Namespace: "default"}, secret)
 	Expect(err).ToNot(HaveOccurred())
@@ -593,12 +640,12 @@ func expectJMXSecret(client ctrlclient.Client, controller *controllers.Container
 	Expect(secret.StringData["CONTAINER_JFR_RJMX_USER"]).To(Equal(expectedSecret.StringData["CONTAINER_JFR_RJMX_USER"]))
 }
 
-func expectExporterService(client ctrlclient.Client, controller *controllers.ContainerJFRReconciler, minimal bool) {
+func expectExporterService(client ctrlclient.Client, controller *controllers.ContainerJFRReconciler, minimal bool, tls bool) {
 	service := &corev1.Service{}
 	err := client.Get(context.Background(), types.NamespacedName{Name: "containerjfr", Namespace: "default"}, service)
 	Expect(kerrors.IsNotFound(err)).To(BeTrue())
 
-	reconcileContainerJFRFully(client, controller, minimal)
+	reconcileContainerJFRFully(client, controller, minimal, tls)
 
 	err = client.Get(context.Background(), types.NamespacedName{Name: "containerjfr", Namespace: "default"}, service)
 	Expect(err).ToNot(HaveOccurred())
@@ -610,12 +657,12 @@ func expectExporterService(client ctrlclient.Client, controller *controllers.Con
 	Expect(service.Spec.Ports).To(Equal(expectedService.Spec.Ports))
 }
 
-func expectCommandChannel(client ctrlclient.Client, controller *controllers.ContainerJFRReconciler, minimal bool) {
+func expectCommandChannel(client ctrlclient.Client, controller *controllers.ContainerJFRReconciler, minimal bool, tls bool) {
 	service := &corev1.Service{}
 	err := client.Get(context.Background(), types.NamespacedName{Name: "containerjfr-command", Namespace: "default"}, service)
 	Expect(kerrors.IsNotFound(err)).To(BeTrue())
 
-	reconcileContainerJFRFully(client, controller, minimal)
+	reconcileContainerJFRFully(client, controller, minimal, tls)
 
 	err = client.Get(context.Background(), types.NamespacedName{Name: "containerjfr-command", Namespace: "default"}, service)
 	Expect(err).ToNot(HaveOccurred())
@@ -627,18 +674,18 @@ func expectCommandChannel(client ctrlclient.Client, controller *controllers.Cont
 	Expect(service.Spec.Ports).To(Equal(expectedService.Spec.Ports))
 }
 
-func expectDeployment(client ctrlclient.Client, controller *controllers.ContainerJFRReconciler, minimal bool) {
+func expectDeployment(client ctrlclient.Client, controller *controllers.ContainerJFRReconciler, minimal bool, tls bool) {
 	deployment := &appsv1.Deployment{}
 	err := client.Get(context.Background(), types.NamespacedName{Name: "containerjfr", Namespace: "default"}, deployment)
 	Expect(kerrors.IsNotFound(err)).To(BeTrue())
 
-	reconcileContainerJFRFully(client, controller, minimal)
-	checkDeployment(client, minimal)
+	reconcileContainerJFRFully(client, controller, minimal, tls)
+	checkDeployment(client, minimal, tls)
 }
 
-func expectIdempotence(client ctrlclient.Client, controller *controllers.ContainerJFRReconciler, minimal bool) {
+func expectIdempotence(client ctrlclient.Client, controller *controllers.ContainerJFRReconciler, minimal bool, tls bool) {
 	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "containerjfr", Namespace: "default"}}
-	reconcileContainerJFRFully(client, controller, minimal)
+	reconcileContainerJFRFully(client, controller, minimal, tls)
 
 	obj := &rhjmcv1beta1.ContainerJFR{}
 	err := client.Get(context.Background(), req.NamespacedName, obj)
@@ -668,27 +715,73 @@ func checkGrafanaService(client ctrlclient.Client) {
 	Expect(service.Spec.Ports).To(Equal(expectedService.Spec.Ports))
 }
 
-func checkDeployment(client ctrlclient.Client, minimal bool) {
+func checkDeployment(client ctrlclient.Client, minimal bool, tls bool) {
 	deployment := &appsv1.Deployment{}
 	err := client.Get(context.Background(), types.NamespacedName{Name: "containerjfr", Namespace: "default"}, deployment)
 	Expect(err).ToNot(HaveOccurred())
 
 	testSpecs := newFakeServiceSpecs(minimal)
-	testTLSConfig := newFakeTLSConfig()
-	testContainer := &rhjmcv1beta1.ContainerJFR{}
-	if minimal {
-		testContainer = test.NewMinimalContainerJFR()
-	} else {
-		testContainer = test.NewContainerJFR()
+	var testTLSConfig *resource_definitions.TLSConfig
+	if tls {
+		testTLSConfig = newFakeTLSConfig()
 	}
-	expectedDeployment := resource_definitions.NewDeploymentForCR(testContainer, &testSpecs, &testTLSConfig)
+	cr := &rhjmcv1beta1.ContainerJFR{}
+	if minimal {
+		cr = test.NewMinimalContainerJFR()
+	} else {
+		cr = test.NewContainerJFR()
+	}
+	expectedDeployment := resource_definitions.NewDeploymentForCR(cr, &testSpecs, testTLSConfig)
 	checkMetadata(deployment, expectedDeployment)
 	Expect(deployment.Spec.Selector).To(Equal(expectedDeployment.Spec.Selector))
+
+	// Check that the networking environment variables are set correctly
+	coreContainer := deployment.Spec.Template.Spec.Containers[0]
+	checkCoreContainer(&coreContainer, minimal, tls)
+
+	if !minimal {
+		// Check that Grafana is configured properly, depending on the environment
+		grafanaContainer := deployment.Spec.Template.Spec.Containers[1]
+		checkGrafanaContainer(&grafanaContainer, tls)
+
+		// Check that JFR Datasource is configured properly
+		datasourceContainer := deployment.Spec.Template.Spec.Containers[2]
+		checkDatasourceContainer(&datasourceContainer)
+	}
 
 	// compare Pod template
 	template := deployment.Spec.Template
 	expectedTemplate := expectedDeployment.Spec.Template
 	Expect(template.ObjectMeta).To(Equal(expectedTemplate.ObjectMeta))
-	Expect(template.Spec.Containers).To(Equal(expectedTemplate.Spec.Containers))
-	Expect(template.Spec.Volumes).To(Equal(expectedTemplate.Spec.Volumes))
+	Expect(template.Spec.Volumes).To(Equal(test.NewVolumes(minimal, tls)))
+}
+
+func checkCoreContainer(container *corev1.Container, minimal bool, tls bool) {
+	Expect(container.Name).To(Equal("containerjfr"))
+	Expect(container.Image).To(Equal("quay.io/rh-jmc-team/container-jfr:1.0.0-BETA6"))
+	Expect(container.Ports).To(ConsistOf(test.NewCorePorts()))
+	Expect(container.Env).To(ConsistOf(test.NewCoreEnvironmentVariables(minimal, tls)))
+	Expect(container.EnvFrom).To(ConsistOf(test.NewCoreEnvFromSource(tls)))
+	Expect(container.VolumeMounts).To(ConsistOf(test.NewCoreVolumeMounts(tls)))
+	Expect(container.LivenessProbe).To(Equal(test.NewCoreLivenessProbe(tls)))
+}
+
+func checkGrafanaContainer(container *corev1.Container, tls bool) {
+	Expect(container.Name).To(Equal("containerjfr-grafana"))
+	Expect(container.Image).To(Equal("quay.io/rh-jmc-team/container-jfr-grafana-dashboard:1.0.0-BETA3"))
+	Expect(container.Ports).To(ConsistOf(test.NewGrafanaPorts()))
+	Expect(container.Env).To(ConsistOf(test.NewGrafanaEnvironmentVariables(tls)))
+	Expect(container.EnvFrom).To(ConsistOf(test.NewGrafanaEnvFromSource()))
+	Expect(container.VolumeMounts).To(ConsistOf(test.NewGrafanaVolumeMounts(tls)))
+	Expect(container.LivenessProbe).To(Equal(test.NewGrafanaLivenessProbe(tls)))
+}
+
+func checkDatasourceContainer(container *corev1.Container) {
+	Expect(container.Name).To(Equal("containerjfr-jfr-datasource"))
+	Expect(container.Image).To(Equal("quay.io/rh-jmc-team/jfr-datasource:0.0.2"))
+	Expect(container.Ports).To(ConsistOf(test.NewDatasourcePorts()))
+	Expect(container.Env).To(ConsistOf(test.NewDatasourceEnvironmentVariables()))
+	Expect(container.EnvFrom).To(BeEmpty())
+	Expect(container.VolumeMounts).To(BeEmpty())
+	Expect(container.LivenessProbe).To(Equal(test.NewDatasourceLivenessProbe()))
 }

--- a/controllers/flightrecorder_controller.go
+++ b/controllers/flightrecorder_controller.go
@@ -98,7 +98,7 @@ func (r *FlightRecorderReconciler) Reconcile(ctx context.Context, request ctrl.R
 	cjfr, err := r.GetContainerJFRClient(ctx, request.Namespace, instance.Spec.JMXCredentials)
 	if err != nil {
 		if err == common.ErrCertNotReady {
-			log.Info("Waiting for CA certificate")
+			reqLogger.Info("Waiting for CA certificate")
 			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 		return reconcile.Result{}, err
@@ -118,10 +118,10 @@ func (r *FlightRecorderReconciler) Reconcile(ctx context.Context, request ctrl.R
 	}
 
 	// Retrieve list of available events
-	log.Info("Listing event types for pod", "name", targetPod.Name, "namespace", targetPod.Namespace)
+	reqLogger.Info("Listing event types for pod", "name", targetPod.Name, "namespace", targetPod.Namespace)
 	events, err := cjfr.ListEventTypes(targetAddr)
 	if err != nil {
-		log.Error(err, "failed to list event types")
+		reqLogger.Error(err, "failed to list event types")
 		return reconcile.Result{}, err
 	}
 
@@ -129,10 +129,10 @@ func (r *FlightRecorderReconciler) Reconcile(ctx context.Context, request ctrl.R
 	instance.Status.Events = events
 
 	// Retrieve list of available templates
-	log.Info("Listing templates for pod", "name", targetPod.Name, "namespace", targetPod.Namespace)
+	reqLogger.Info("Listing templates for pod", "name", targetPod.Name, "namespace", targetPod.Namespace)
 	templates, err := cjfr.ListTemplates(targetAddr)
 	if err != nil {
-		log.Error(err, "failed to list templates")
+		reqLogger.Error(err, "failed to list templates")
 		return reconcile.Result{}, err
 	}
 

--- a/controllers/flightrecorder_controller_test.go
+++ b/controllers/flightrecorder_controller_test.go
@@ -284,6 +284,18 @@ var _ = Describe("FlightRecorderController", func() {
 				expectFlightRecorderReconcileError(controller)
 			})
 		})
+		Context("successfully updates FlightRecorder CR with TLS disabled", func() {
+			BeforeEach(func() {
+				handlers = []http.HandlerFunc{
+					test.NewListEventTypesHandler(),
+					test.NewListTemplatesHandler(),
+				}
+				tls = false
+			})
+			It("should update event type list", func() {
+				expectFlightRecorderReconcileSuccess(controller, client)
+			})
+		})
 	})
 })
 

--- a/controllers/flightrecorder_controller_test.go
+++ b/controllers/flightrecorder_controller_test.go
@@ -63,6 +63,7 @@ var _ = Describe("FlightRecorderController", func() {
 		server     *test.ContainerJFRServer
 		client     client.Client
 		controller *controllers.FlightRecorderReconciler
+		tls        bool
 	)
 
 	JustBeforeEach(func() {
@@ -71,12 +72,12 @@ var _ = Describe("FlightRecorderController", func() {
 		s := test.NewTestScheme()
 
 		client = fake.NewFakeClientWithScheme(s, objs...)
-		server = test.NewServer(client, handlers)
+		server = test.NewServer(client, handlers, tls)
 		controller = &controllers.FlightRecorderReconciler{
 			Client:     client,
 			Scheme:     s,
 			Log:        logger,
-			Reconciler: test.NewTestReconciler(server, client),
+			Reconciler: test.NewTestReconciler(server, client, tls),
 		}
 	})
 
@@ -91,12 +92,14 @@ var _ = Describe("FlightRecorderController", func() {
 			test.NewContainerJFRService(), test.NewJMXAuthSecret(),
 		}
 		handlers = []http.HandlerFunc{}
+		tls = true
 	})
 
 	AfterEach(func() {
 		// Reset test inputs
 		objs = nil
 		handlers = nil
+		tls = false
 	})
 
 	Describe("reconciling a request", func() {

--- a/controllers/recording_controller.go
+++ b/controllers/recording_controller.go
@@ -125,7 +125,7 @@ func (r *RecordingReconciler) Reconcile(ctx context.Context, request ctrl.Reques
 	// Obtain a client configured to communicate with Container JFR
 	cjfr, err := r.GetContainerJFRClient(ctx, request.Namespace, jfr.Spec.JMXCredentials)
 	if err != nil {
-		return requeueIfNotReady(err)
+		return requeueIfIngressNotReady(err)
 	}
 
 	// Look up pod corresponding to this FlightRecorder object
@@ -400,7 +400,7 @@ func (r *RecordingReconciler) deleteWithoutLiveTarget(ctx context.Context, recor
 	// Obtain a client configured to communicate with Container JFR without JMX credentials
 	cjfr, err := r.GetContainerJFRClient(ctx, recording.Namespace, nil)
 	if err != nil {
-		return requeueIfNotReady(err)
+		return requeueIfIngressNotReady(err)
 	}
 
 	// Delete any persisted JFR file for this recording

--- a/controllers/recording_controller.go
+++ b/controllers/recording_controller.go
@@ -62,13 +62,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
-
-var log = logf.Log.WithName("controller_recording")
 
 // RecordingReconciler reconciles a Recording object
 type RecordingReconciler struct {
@@ -125,7 +122,7 @@ func (r *RecordingReconciler) Reconcile(ctx context.Context, request ctrl.Reques
 	// Obtain a client configured to communicate with Container JFR
 	cjfr, err := r.GetContainerJFRClient(ctx, request.Namespace, jfr.Spec.JMXCredentials)
 	if err != nil {
-		return requeueIfIngressNotReady(err)
+		return r.requeueIfNotReady(err)
 	}
 
 	// Look up pod corresponding to this FlightRecorder object
@@ -190,7 +187,7 @@ func (r *RecordingReconciler) Reconcile(ctx context.Context, request ctrl.Reques
 	// Updated Download URL, use existing URL as default
 	downloadURL := instance.Status.DownloadURL
 	reportURL := instance.Status.ReportURL
-	descriptor, err := findRecordingByName(cjfr, targetAddr, instance.Spec.Name)
+	descriptor, err := r.findRecordingByName(cjfr, targetAddr, instance.Spec.Name)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -213,7 +210,7 @@ func (r *RecordingReconciler) Reconcile(ctx context.Context, request ctrl.Reques
 	// Archive completed recording if requested and not already done
 	isStopped := instance.Status.State != nil && *instance.Status.State == rhjmcv1beta1.RecordingStateStopped
 	if instance.Spec.Archive && isStopped {
-		recording, err := archiveStoppedRecording(cjfr, instance, targetAddr)
+		recording, err := r.archiveStoppedRecording(cjfr, instance, targetAddr)
 		if err != nil {
 			return reconcile.Result{}, err
 		} else if recording == nil {
@@ -250,7 +247,7 @@ func (r *RecordingReconciler) Reconcile(ctx context.Context, request ctrl.Reques
 func (r *RecordingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	c := ctrl.NewControllerManagedBy(mgr)
 	c = c.For(&rhjmcv1beta1.Recording{})
-	c = watchFlightRecorders(c, mgr.GetClient())
+	c = r.watchFlightRecorders(c, mgr.GetClient())
 
 	return c.Complete(r)
 }
@@ -284,11 +281,11 @@ func (r *RecordingReconciler) getFlightRecorder(ctx context.Context, recording *
 	return jfr, nil
 }
 
-func findSavedRecording(cjfr jfrclient.ContainerJfrClient, filename string) (*jfrclient.SavedRecording, error) {
+func (r *RecordingReconciler) findSavedRecording(cjfr jfrclient.ContainerJfrClient, filename string) (*jfrclient.SavedRecording, error) {
 	// Look for our saved recording in list from Container JFR
 	savedRecordings, err := cjfr.ListSavedRecordings()
 	if err != nil {
-		log.Error(err, "failed to list saved flight recordings")
+		r.Log.Error(err, "failed to list saved flight recordings")
 		return nil, err
 	}
 	for idx, saved := range savedRecordings {
@@ -299,7 +296,7 @@ func findSavedRecording(cjfr jfrclient.ContainerJfrClient, filename string) (*jf
 	return nil, nil
 }
 
-func archiveStoppedRecording(cjfr jfrclient.ContainerJfrClient, recording *rhjmcv1beta1.Recording,
+func (r *RecordingReconciler) archiveStoppedRecording(cjfr jfrclient.ContainerJfrClient, recording *rhjmcv1beta1.Recording,
 	target *jfrclient.TargetAddress) (*jfrclient.SavedRecording, error) {
 	// Check if existing download URL points to an archived recording
 	jfrFile, err := recordingFilename(*recording.Status.DownloadURL)
@@ -307,7 +304,7 @@ func archiveStoppedRecording(cjfr jfrclient.ContainerJfrClient, recording *rhjmc
 		return nil, err
 	}
 
-	savedRecording, err := findSavedRecording(cjfr, *jfrFile)
+	savedRecording, err := r.findSavedRecording(cjfr, *jfrFile)
 	if err != nil {
 		return nil, err
 	}
@@ -317,22 +314,22 @@ func archiveStoppedRecording(cjfr jfrclient.ContainerJfrClient, recording *rhjmc
 	}
 
 	// Recording hasn't been archived yet, do so now
-	log.Info("saving recording", "name", recording.Spec.Name)
+	r.Log.Info("saving recording", "name", recording.Spec.Name)
 	filename, err := cjfr.SaveRecording(target, recording.Spec.Name)
 	if err != nil {
-		log.Error(err, "failed to save recording", "name", recording.Spec.Name)
+		r.Log.Error(err, "failed to save recording", "name", recording.Spec.Name)
 		return nil, err
 	}
 
 	// Look up full URL for filename returned by SaveRecording
-	return findSavedRecording(cjfr, *filename)
+	return r.findSavedRecording(cjfr, *filename)
 }
 
-func removeRecording(cjfr jfrclient.ContainerJfrClient, target *jfrclient.TargetAddress,
+func (r *RecordingReconciler) removeRecording(cjfr jfrclient.ContainerJfrClient, target *jfrclient.TargetAddress,
 	recording *rhjmcv1beta1.Recording) error {
 	// Check if recording exists in Container JFR's in-memory list
 	recName := recording.Spec.Name
-	found, err := findRecordingByName(cjfr, target, recName)
+	found, err := r.findRecordingByName(cjfr, target, recName)
 	if err != nil {
 		return err
 	}
@@ -342,7 +339,7 @@ func removeRecording(cjfr jfrclient.ContainerJfrClient, target *jfrclient.Target
 		if err != nil {
 			return err
 		}
-		log.Info("recording successfully deleted", "name", recName)
+		r.Log.Info("recording successfully deleted", "name", recName)
 	}
 	return nil
 }
@@ -355,7 +352,7 @@ func (r *RecordingReconciler) removeSavedRecording(cjfr jfrclient.ContainerJfrCl
 			return err
 		}
 		// Look for this JFR file within Container JFR's list of saved recordings
-		found, err := findSavedRecording(cjfr, *jfrFile)
+		found, err := r.findSavedRecording(cjfr, *jfrFile)
 		if err != nil {
 			return err
 		}
@@ -400,7 +397,7 @@ func (r *RecordingReconciler) deleteWithoutLiveTarget(ctx context.Context, recor
 	// Obtain a client configured to communicate with Container JFR without JMX credentials
 	cjfr, err := r.GetContainerJFRClient(ctx, recording.Namespace, nil)
 	if err != nil {
-		return requeueIfIngressNotReady(err)
+		return r.requeueIfNotReady(err)
 	}
 
 	// Delete any persisted JFR file for this recording
@@ -426,7 +423,7 @@ func (r *RecordingReconciler) deleteWithLiveTarget(ctx context.Context, cjfr jfr
 	}
 
 	// Delete in-memory recording in Container JFR
-	err = removeRecording(cjfr, target, recording)
+	err = r.removeRecording(cjfr, target, recording)
 	if err != nil {
 		reqLogger.Error(err, "failed to delete recording in Container JFR")
 		return reconcile.Result{}, err
@@ -437,7 +434,7 @@ func (r *RecordingReconciler) deleteWithLiveTarget(ctx context.Context, cjfr jfr
 	return reconcile.Result{}, err
 }
 
-func watchFlightRecorders(builder *builder.Builder, cl client.Client) *builder.Builder {
+func (r *RecordingReconciler) watchFlightRecorders(builder *builder.Builder, cl client.Client) *builder.Builder {
 	ctx := context.Background()
 	jfrPredicate := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
@@ -459,7 +456,7 @@ func watchFlightRecorders(builder *builder.Builder, cl client.Client) *builder.B
 			LabelSelector: selector,
 		})
 		if err != nil {
-			log.Error(err, "Failed to list Recordings", "namespace", obj.GetNamespace(),
+			r.Log.Error(err, "Failed to list Recordings", "namespace", obj.GetNamespace(),
 				"selector", selector.String())
 		}
 
@@ -485,12 +482,12 @@ func watchFlightRecorders(builder *builder.Builder, cl client.Client) *builder.B
 	)
 }
 
-func findRecordingByName(cjfr jfrclient.ContainerJfrClient, target *jfrclient.TargetAddress,
+func (r *RecordingReconciler) findRecordingByName(cjfr jfrclient.ContainerJfrClient, target *jfrclient.TargetAddress,
 	name string) (*jfrclient.RecordingDescriptor, error) {
 	// Get an updated list of in-memory flight recordings
 	descriptors, err := cjfr.ListRecordings(target)
 	if err != nil {
-		log.Error(err, "failed to list flight recordings", "name", name)
+		r.Log.Error(err, "failed to list flight recordings", "name", name)
 		return nil, err
 	}
 
@@ -537,9 +534,9 @@ func shouldStopRecording(recording *rhjmcv1beta1.Recording) bool {
 		*current != rhjmcv1beta1.RecordingStateStopping
 }
 
-func requeueIfNotReady(err error) (reconcile.Result, error) {
+func (r *RecordingReconciler) requeueIfNotReady(err error) (reconcile.Result, error) {
 	if err == common.ErrCertNotReady {
-		log.Info("Waiting for CA certificate")
+		r.Log.Info("Waiting for CA certificate")
 		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 	return reconcile.Result{}, err

--- a/controllers/recording_controller_test.go
+++ b/controllers/recording_controller_test.go
@@ -74,12 +74,12 @@ var _ = Describe("RecordingController", func() {
 		s := test.NewTestScheme()
 
 		client = fake.NewFakeClientWithScheme(s, objs...)
-		server = test.NewServer(client, handlers)
+		server = test.NewServer(client, handlers, true)
 		controller = &controllers.RecordingReconciler{
 			Client:     client,
 			Scheme:     s,
 			Log:        logger,
-			Reconciler: test.NewTestReconciler(server, client),
+			Reconciler: test.NewTestReconciler(server, client, true),
 		}
 	})
 

--- a/test/resources.go
+++ b/test/resources.go
@@ -934,6 +934,15 @@ func NewDatasourceLivenessProbe() *corev1.Probe {
 	}
 }
 
+func NewDeploymentSelector() *metav1.LabelSelector {
+	return &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"app":  "containerjfr",
+			"kind": "containerjfr",
+		},
+	}
+}
+
 func NewVolumes(minimal bool, tls bool) []corev1.Volume {
 	volumes := []corev1.Volume{
 		{

--- a/test/resources.go
+++ b/test/resources.go
@@ -48,6 +48,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
@@ -665,8 +666,172 @@ func NewDefaultPVCWithLabel() *corev1.PersistentVolumeClaim {
 	}, nil)
 }
 
-func NewVolumeMountsWithSecrets() *[]corev1.VolumeMount {
-	return &[]corev1.VolumeMount{
+func NewCorePorts() []corev1.ContainerPort {
+	return []corev1.ContainerPort{
+		{
+			ContainerPort: 8181,
+		},
+		{
+			ContainerPort: 9090,
+		},
+		{
+			ContainerPort: 9091,
+		},
+	}
+}
+
+func NewGrafanaPorts() []corev1.ContainerPort {
+	return []corev1.ContainerPort{
+		{
+			ContainerPort: 3000,
+		},
+	}
+}
+
+func NewDatasourcePorts() []corev1.ContainerPort {
+	return []corev1.ContainerPort{
+		{
+			ContainerPort: 8080,
+		},
+	}
+}
+
+func NewCoreEnvironmentVariables(minimal bool, tls bool) []corev1.EnvVar {
+	envs := []corev1.EnvVar{
+		{
+			Name:  "CONTAINER_JFR_PLATFORM",
+			Value: "com.redhat.rhjmc.containerjfr.platform.internal.OpenShiftPlatformStrategy",
+		},
+		{
+			Name:  "CONTAINER_JFR_SSL_PROXIED",
+			Value: "true",
+		},
+		{
+			Name:  "CONTAINER_JFR_ALLOW_UNTRUSTED_SSL",
+			Value: "true",
+		},
+		{
+			Name:  "CONTAINER_JFR_WEB_PORT",
+			Value: "8181",
+		},
+		{
+			Name:  "CONTAINER_JFR_EXT_WEB_PORT",
+			Value: "443",
+		},
+		{
+			Name:  "CONTAINER_JFR_WEB_HOST",
+			Value: "containerjfr.example.com",
+		},
+		{
+			Name:  "CONTAINER_JFR_LISTEN_PORT",
+			Value: "9090",
+		},
+		{
+			Name:  "CONTAINER_JFR_EXT_LISTEN_PORT",
+			Value: "443",
+		},
+		{
+			Name:  "CONTAINER_JFR_LISTEN_HOST",
+			Value: "containerjfr-command.example.com",
+		},
+		{
+			Name:  "CONTAINER_JFR_TEMPLATE_PATH",
+			Value: "/templates",
+		},
+	}
+	if !minimal {
+		envs = append(envs,
+			corev1.EnvVar{
+				Name:  "GRAFANA_DASHBOARD_URL",
+				Value: "https://containerjfr-grafana.example.com",
+			},
+			corev1.EnvVar{
+				Name:  "GRAFANA_DATASOURCE_URL",
+				Value: "http://127.0.0.1:8080",
+			})
+	}
+	if !tls {
+		envs = append(envs,
+			corev1.EnvVar{
+				Name:  "CONTAINER_JFR_DISABLE_SSL",
+				Value: "true",
+			})
+	} else {
+		envs = append(envs, corev1.EnvVar{
+			Name:  "KEYSTORE_PATH",
+			Value: "/var/run/secrets/rhjmc.redhat.com/containerjfr-tls/keystore.p12",
+		})
+	}
+	return envs
+}
+
+func NewGrafanaEnvironmentVariables(tls bool) []corev1.EnvVar {
+	envs := []corev1.EnvVar{
+		{
+			Name:  "JFR_DATASOURCE_URL",
+			Value: "http://127.0.0.1:8080",
+		},
+	}
+	if tls {
+		envs = append(envs, corev1.EnvVar{
+			Name:  "GF_SERVER_PROTOCOL",
+			Value: "https",
+		}, corev1.EnvVar{
+			Name:  "GF_SERVER_CERT_KEY",
+			Value: "/var/run/secrets/rhjmc.redhat.com/containerjfr-grafana-tls/tls.key",
+		}, corev1.EnvVar{
+			Name:  "GF_SERVER_CERT_FILE",
+			Value: "/var/run/secrets/rhjmc.redhat.com/containerjfr-grafana-tls/tls.crt",
+		})
+	}
+	return envs
+}
+
+func NewDatasourceEnvironmentVariables() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name:  "LISTEN_HOST",
+			Value: "127.0.0.1",
+		},
+	}
+}
+
+func NewCoreEnvFromSource(tls bool) []corev1.EnvFromSource {
+	envsFrom := []corev1.EnvFromSource{
+		{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "containerjfr-jmx-auth",
+				},
+			},
+		},
+	}
+	if tls {
+		envsFrom = append(envsFrom, corev1.EnvFromSource{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "containerjfr-keystore",
+				},
+			},
+		})
+	}
+	return envsFrom
+}
+
+func NewGrafanaEnvFromSource() []corev1.EnvFromSource {
+	return []corev1.EnvFromSource{
+		{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "containerjfr-grafana-basic",
+				},
+			},
+		},
+	}
+}
+
+func NewCoreVolumeMounts(tls bool) []corev1.VolumeMount {
+	mounts := []corev1.VolumeMount{
 		{
 			Name:      "containerjfr",
 			ReadOnly:  false,
@@ -679,35 +844,98 @@ func NewVolumeMountsWithSecrets() *[]corev1.VolumeMount {
 			MountPath: "templates",
 			SubPath:   "templates",
 		},
-		{
-			Name:      "tls-secret",
-			ReadOnly:  true,
-			MountPath: "/var/run/secrets/rhjmc.redhat.com/containerjfr-tls/keystore.p12",
-			SubPath:   "keystore.p12",
-		},
-		{
-			Name:      "tls-secret",
-			ReadOnly:  true,
-			MountPath: "/truststore/containerjfr-ca.crt",
-			SubPath:   "ca.crt",
-		},
-		{
+	}
+	if tls {
+		mounts = append(mounts,
+			corev1.VolumeMount{
+				Name:      "tls-secret",
+				ReadOnly:  true,
+				MountPath: "/var/run/secrets/rhjmc.redhat.com/containerjfr-tls/keystore.p12",
+				SubPath:   "keystore.p12",
+			},
+			corev1.VolumeMount{
+				Name:      "tls-secret",
+				ReadOnly:  true,
+				MountPath: "/truststore/containerjfr-ca.crt",
+				SubPath:   "ca.crt",
+			})
+	}
+	return mounts
+}
+
+func NewGrafanaVolumeMounts(tls bool) []corev1.VolumeMount {
+	mounts := []corev1.VolumeMount{}
+	if tls {
+		mounts = append(mounts,
+			corev1.VolumeMount{
+				Name:      "grafana-tls-secret",
+				MountPath: "/var/run/secrets/rhjmc.redhat.com/containerjfr-grafana-tls",
+				ReadOnly:  true,
+			})
+	}
+	return mounts
+}
+
+func NewVolumeMountsWithSecrets() []corev1.VolumeMount {
+	return append(NewCoreVolumeMounts(true),
+		corev1.VolumeMount{
 			Name:      "testCert1",
 			ReadOnly:  true,
 			MountPath: "/truststore/testCert1_test.crt",
 			SubPath:   "test.crt",
 		},
-		{
+		corev1.VolumeMount{
 			Name:      "testCert2",
 			ReadOnly:  true,
 			MountPath: "/truststore/testCert2_tls.crt",
 			SubPath:   "tls.crt",
+		})
+}
+
+func NewCoreLivenessProbe(tls bool) *corev1.Probe {
+	protocol := corev1.URISchemeHTTPS
+	if !tls {
+		protocol = corev1.URISchemeHTTP
+	}
+	return &corev1.Probe{
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Port:   intstr.IntOrString{IntVal: 8181},
+				Path:   "/api/v1/clienturl",
+				Scheme: protocol,
+			},
 		},
 	}
 }
 
-func NewVolumesWithSecrets() *[]corev1.Volume {
-	return &[]corev1.Volume{
+func NewGrafanaLivenessProbe(tls bool) *corev1.Probe {
+	protocol := corev1.URISchemeHTTPS
+	if !tls {
+		protocol = corev1.URISchemeHTTP
+	}
+	return &corev1.Probe{
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Port:   intstr.IntOrString{IntVal: 3000},
+				Path:   "/api/health",
+				Scheme: protocol,
+			},
+		},
+	}
+}
+
+func NewDatasourceLivenessProbe() *corev1.Probe {
+	return &corev1.Probe{
+		Handler: corev1.Handler{
+			Exec: &corev1.ExecAction{
+				Command: []string{"curl", "--fail", "http://127.0.0.1:8080"},
+			},
+		},
+	}
+}
+
+func NewVolumes(minimal bool, tls bool) []corev1.Volume {
+	volumes := []corev1.Volume{
 		{
 			Name: "containerjfr",
 			VolumeSource: corev1.VolumeSource{
@@ -717,23 +945,35 @@ func NewVolumesWithSecrets() *[]corev1.Volume {
 				},
 			},
 		},
-		{
-			Name: "tls-secret",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: "containerjfr-tls",
+	}
+	if tls {
+		volumes = append(volumes,
+			corev1.Volume{
+				Name: "tls-secret",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: "containerjfr-tls",
+					},
 				},
-			},
-		},
-		{
-			Name: "grafana-tls-secret",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: "containerjfr-grafana-tls",
-				},
-			},
-		},
-		{
+			})
+		if !minimal {
+			volumes = append(volumes,
+				corev1.Volume{
+					Name: "grafana-tls-secret",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "containerjfr-grafana-tls",
+						},
+					},
+				})
+		}
+	}
+	return volumes
+}
+
+func NewVolumesWithSecrets() []corev1.Volume {
+	return append(NewVolumes(false, true),
+		corev1.Volume{
 			Name: "testCert1",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
@@ -741,13 +981,12 @@ func NewVolumesWithSecrets() *[]corev1.Volume {
 				},
 			},
 		},
-		{
+		corev1.Volume{
 			Name: "testCert2",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: "testCert2",
 				},
 			},
-		},
-	}
+		})
 }

--- a/test/server.go
+++ b/test/server.go
@@ -56,12 +56,17 @@ type ContainerJFRServer struct {
 }
 
 // NewServer creates a ContainerJFRServer for use by unit tests
-func NewServer(client client.Client, handlers []http.HandlerFunc) *ContainerJFRServer {
-	s := ghttp.NewTLSServer()
-	s.AppendHandlers(handlers...)
-	updateCACert(client, s)
+func NewServer(client client.Client, handlers []http.HandlerFunc, tls bool) *ContainerJFRServer {
+	var server *ghttp.Server
+	if !tls {
+		server = ghttp.NewServer()
+	} else {
+		server = ghttp.NewTLSServer()
+		updateCACert(client, server)
+	}
+	server.AppendHandlers(handlers...)
 	return &ContainerJFRServer{
-		impl: s,
+		impl: server,
 	}
 }
 


### PR DESCRIPTION
This PR fixes the `DISABLE_SERVICE_TLS` environment variable functionality to properly set up Container JFR without requiring cert-manager. I modified the ServiceSpecs struct to use URLs instead of strings. This allows us to pass the scheme, host and port to `NewDeploymentForCR`, which can adjust the environment variables as necessary. Right now, Routes always use some form of TLS even without cert-manager, but with incoming Ingress support, this will not be true. This PR makes the code more flexible to support that use case.

When `DISABLE_SERVICE_TLS` is set to true in the Makefile, the `deploy` and `deploy_bundle` targets use `kubectl set env` to add the environment variable to the operator deployment.

I added some tests to exercise the cases where code paths diverge when cert-manager is disabled. I also modified the effected tests to treat the `resource_definitions` package as a black box. Instead of using this package for the expectation for the tests, the expected Kubernetes objects are placed in the `test` package. We might be able to improve this further by moving the objects to golden JSON/YAML files.

There are a number of related minor fixes as well:
- Print a log message and requeue when the Route configuration is not ready, instead of returning an error. This tidies up the log a bit.
- The `redhat.com/containerJfrUrl` contains the full URL, including the scheme. The README has been updated accordingly.
- The test arguments are changed in the Makefile in order to ensure the `ginkgo` CLI outputs the coverage file.
- Removed the leftover package-scoped log in recording_controller.go, and adjusted log calls to use their controller's log.

Fixes: #165