### PR TITLE
Add owned resources API markers

### DIFF
--- a/api/v1beta1/containerjfr_types.go
+++ b/api/v1beta1/containerjfr_types.go
@@ -100,6 +100,7 @@ type PersistentVolumeClaimConfig struct {
 // +kubebuilder:resource:path=containerjfrs,scope=Namespaced
 
 // ContainerJFR is the Schema for the containerjfrs API
+//+operator-sdk:csv:customresourcedefinitions:resources={{Deployment,v1},{PersistentVolumeClaim,v1},{Secret,v1},{Service,v1},{Route,v1},{FlightRecorder,v1beta1},{ConsoleLink,v1}}
 type ContainerJFR struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/containerjfr_types.go
+++ b/api/v1beta1/containerjfr_types.go
@@ -100,7 +100,7 @@ type PersistentVolumeClaimConfig struct {
 // +kubebuilder:resource:path=containerjfrs,scope=Namespaced
 
 // ContainerJFR is the Schema for the containerjfrs API
-//+operator-sdk:csv:customresourcedefinitions:resources={{Deployment,v1},{PersistentVolumeClaim,v1},{Secret,v1},{Service,v1},{Route,v1},{FlightRecorder,v1beta1},{ConsoleLink,v1}}
+//+operator-sdk:csv:customresourcedefinitions:resources={{Deployment,v1},{Ingress,v1},{PersistentVolumeClaim,v1},{Secret,v1},{Service,v1},{Route,v1},{ConsoleLink,v1}}
 type ContainerJFR struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/flightrecorder_types.go
+++ b/api/v1beta1/flightrecorder_types.go
@@ -154,6 +154,7 @@ type JMXAuthSecret struct {
 // +kubebuilder:subresource:status
 
 // FlightRecorder is the Schema for the flightrecorders API
+//+operator-sdk:csv:customresourcedefinitions:resources={{Pod,v1},{Secret,v1},{Service,v1}}
 type FlightRecorder struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/recording_types.go
+++ b/api/v1beta1/recording_types.go
@@ -124,6 +124,7 @@ type RecordingStatus struct {
 // +kubebuilder:resource:path=recordings,scope=Namespaced
 
 // Recording is the Schema for the recordings API
+//+operator-sdk:csv:customresourcedefinitions:resources={{Pod,v1},{Secret,v1},{Service,v1}}
 type Recording struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle/manifests/container-jfr-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/container-jfr-operator.clusterserviceversion.yaml
@@ -75,6 +75,28 @@ spec:
       displayName: Container JFR
       kind: ContainerJFR
       name: containerjfrs.rhjmc.redhat.com
+      resources:
+      - kind: ConsoleLink
+        name: ""
+        version: v1
+      - kind: Deployment
+        name: ""
+        version: v1
+      - kind: FlightRecorder
+        name: ""
+        version: v1beta1
+      - kind: PersistentVolumeClaim
+        name: ""
+        version: v1
+      - kind: Route
+        name: ""
+        version: v1
+      - kind: Secret
+        name: ""
+        version: v1
+      - kind: Service
+        name: ""
+        version: v1
       specDescriptors:
       - description: Deploy a pared-down ContainerJFR instance with no Grafana dashboard or jfr-datasource and no web-client UI.
         displayName: Minimal Deployment
@@ -103,6 +125,16 @@ spec:
       displayName: Flight Recorder
       kind: FlightRecorder
       name: flightrecorders.rhjmc.redhat.com
+      resources:
+      - kind: Pod
+        name: ""
+        version: v1
+      - kind: Secret
+        name: ""
+        version: v1
+      - kind: Service
+        name: ""
+        version: v1
       specDescriptors:
       - description: If JMX authentication is enabled for this FlightRecorder's JVM, specify the credentials in a secret and reference it here
         displayName: JMXCredentials
@@ -130,6 +162,16 @@ spec:
       displayName: Recording
       kind: Recording
       name: recordings.rhjmc.redhat.com
+      resources:
+      - kind: Pod
+        name: ""
+        version: v1
+      - kind: Secret
+        name: ""
+        version: v1
+      - kind: Service
+        name: ""
+        version: v1
       specDescriptors:
       - description: Whether this recording should be saved to persistent storage. If true, the JFR file will be retained until this object is deleted. If false, the JFR file will be deleted when its corresponding JVM exits.
         displayName: Archive

--- a/bundle/manifests/container-jfr-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/container-jfr-operator.clusterserviceversion.yaml
@@ -82,9 +82,9 @@ spec:
       - kind: Deployment
         name: ""
         version: v1
-      - kind: FlightRecorder
+      - kind: Ingress
         name: ""
-        version: v1beta1
+        version: v1
       - kind: PersistentVolumeClaim
         name: ""
         version: v1

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,9 +5,9 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: container-jfr-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.4.0+git
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/config/manifests/bases/container-jfr-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/container-jfr-operator.clusterserviceversion.yaml
@@ -75,9 +75,9 @@ spec:
       - kind: Deployment
         name: ""
         version: v1
-      - kind: FlightRecorder
+      - kind: Ingress
         name: ""
-        version: v1beta1
+        version: v1
       - kind: PersistentVolumeClaim
         name: ""
         version: v1

--- a/config/manifests/bases/container-jfr-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/container-jfr-operator.clusterserviceversion.yaml
@@ -68,6 +68,28 @@ spec:
       displayName: Container JFR
       kind: ContainerJFR
       name: containerjfrs.rhjmc.redhat.com
+      resources:
+      - kind: ConsoleLink
+        name: ""
+        version: v1
+      - kind: Deployment
+        name: ""
+        version: v1
+      - kind: FlightRecorder
+        name: ""
+        version: v1beta1
+      - kind: PersistentVolumeClaim
+        name: ""
+        version: v1
+      - kind: Route
+        name: ""
+        version: v1
+      - kind: Secret
+        name: ""
+        version: v1
+      - kind: Service
+        name: ""
+        version: v1
       specDescriptors:
       - description: Deploy a pared-down ContainerJFR instance with no Grafana dashboard or jfr-datasource and no web-client UI.
         displayName: Minimal Deployment
@@ -96,6 +118,16 @@ spec:
       displayName: Flight Recorder
       kind: FlightRecorder
       name: flightrecorders.rhjmc.redhat.com
+      resources:
+      - kind: Pod
+        name: ""
+        version: v1
+      - kind: Secret
+        name: ""
+        version: v1
+      - kind: Service
+        name: ""
+        version: v1
       specDescriptors:
       - description: If JMX authentication is enabled for this FlightRecorder's JVM, specify the credentials in a secret and reference it here
         displayName: JMXCredentials
@@ -123,6 +155,16 @@ spec:
       displayName: Recording
       kind: Recording
       name: recordings.rhjmc.redhat.com
+      resources:
+      - kind: Pod
+        name: ""
+        version: v1
+      - kind: Secret
+        name: ""
+        version: v1
+      - kind: Service
+        name: ""
+        version: v1
       specDescriptors:
       - description: Whether this recording should be saved to persistent storage. If true, the JFR file will be retained until this object is deleted. If false, the JFR file will be deleted when its corresponding JVM exits.
         displayName: Archive


### PR DESCRIPTION
Related to #150

This fixes the scorecard test `olm-crds-have-resources`.