### PR TITLE
Add Dashboard URL to ContainerJFR CR Status

### DIFF
--- a/api/v1beta1/containerjfr_types.go
+++ b/api/v1beta1/containerjfr_types.go
@@ -59,8 +59,8 @@ type ContainerJFRSpec struct {
 
 // ContainerJFRStatus defines the observed state of ContainerJFR
 type ContainerJFRStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
+	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors={"urn:alm:descriptor:org.w3:link"}
+	DashboardURL string `json:"dashboardUrl"`
 }
 
 // StorageConfiguration provides customization to the storage created by

--- a/api/v1beta1/containerjfr_types.go
+++ b/api/v1beta1/containerjfr_types.go
@@ -60,7 +60,7 @@ type ContainerJFRSpec struct {
 // ContainerJFRStatus defines the observed state of ContainerJFR
 type ContainerJFRStatus struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors={"urn:alm:descriptor:org.w3:link"}
-	DashboardURL string `json:"dashboardUrl"`
+	ApplicationURL string `json:"applicationUrl"`
 }
 
 // StorageConfiguration provides customization to the storage created by

--- a/bundle/manifests/container-jfr-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/container-jfr-operator.clusterserviceversion.yaml
@@ -120,6 +120,11 @@ spec:
         path: trustedCertSecrets[0].secretName
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Secret
+      statusDescriptors:
+      - displayName: Dashboard URL
+        path: dashboardUrl
+        x-descriptors:
+        - urn:alm:descriptor:org.w3:link
       version: v1beta1
     - description: FlightRecorder is the Schema for the flightrecorders API
       displayName: Flight Recorder

--- a/bundle/manifests/container-jfr-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/container-jfr-operator.clusterserviceversion.yaml
@@ -121,8 +121,8 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Secret
       statusDescriptors:
-      - displayName: Dashboard URL
-        path: dashboardUrl
+      - displayName: Application URL
+        path: applicationUrl
         x-descriptors:
         - urn:alm:descriptor:org.w3:link
       version: v1beta1

--- a/bundle/manifests/rhjmc.redhat.com_containerjfrs.yaml
+++ b/bundle/manifests/rhjmc.redhat.com_containerjfrs.yaml
@@ -157,10 +157,10 @@ spec:
           status:
             description: ContainerJFRStatus defines the observed state of ContainerJFR
             properties:
-              dashboardUrl:
+              applicationUrl:
                 type: string
             required:
-            - dashboardUrl
+            - applicationUrl
             type: object
         type: object
     served: true

--- a/bundle/manifests/rhjmc.redhat.com_containerjfrs.yaml
+++ b/bundle/manifests/rhjmc.redhat.com_containerjfrs.yaml
@@ -156,6 +156,11 @@ spec:
             type: object
           status:
             description: ContainerJFRStatus defines the observed state of ContainerJFR
+            properties:
+              dashboardUrl:
+                type: string
+            required:
+            - dashboardUrl
             type: object
         type: object
     served: true

--- a/config/crd/bases/rhjmc.redhat.com_containerjfrs.yaml
+++ b/config/crd/bases/rhjmc.redhat.com_containerjfrs.yaml
@@ -218,10 +218,10 @@ spec:
           status:
             description: ContainerJFRStatus defines the observed state of ContainerJFR
             properties:
-              dashboardUrl:
+              applicationUrl:
                 type: string
             required:
-            - dashboardUrl
+            - applicationUrl
             type: object
         type: object
     served: true

--- a/config/crd/bases/rhjmc.redhat.com_containerjfrs.yaml
+++ b/config/crd/bases/rhjmc.redhat.com_containerjfrs.yaml
@@ -217,6 +217,11 @@ spec:
             type: object
           status:
             description: ContainerJFRStatus defines the observed state of ContainerJFR
+            properties:
+              dashboardUrl:
+                type: string
+            required:
+            - dashboardUrl
             type: object
         type: object
     served: true

--- a/config/manifests/bases/container-jfr-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/container-jfr-operator.clusterserviceversion.yaml
@@ -114,8 +114,8 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Secret
       statusDescriptors:
-      - displayName: Dashboard URL
-        path: dashboardUrl
+      - displayName: Application URL
+        path: applicationUrl
         x-descriptors:
         - urn:alm:descriptor:org.w3:link
       version: v1beta1

--- a/config/manifests/bases/container-jfr-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/container-jfr-operator.clusterserviceversion.yaml
@@ -113,6 +113,11 @@ spec:
         path: trustedCertSecrets[0].secretName
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Secret
+      statusDescriptors:
+      - displayName: Dashboard URL
+        path: dashboardUrl
+        x-descriptors:
+        - urn:alm:descriptor:org.w3:link
       version: v1beta1
     - description: FlightRecorder is the Schema for the flightrecorders API
       displayName: Flight Recorder

--- a/controllers/common/resource_definitions/resource_definitions.go
+++ b/controllers/common/resource_definitions/resource_definitions.go
@@ -119,7 +119,6 @@ func NewDeploymentForCR(cr *rhjmcv1beta1.ContainerJFR, specs *ServiceSpecs, tls 
 				"app.kubernetes.io/name": "container-jfr",
 			},
 			Annotations: map[string]string{
-				"redhat.com/containerJfrUrl":   specs.CoreURL.String(),
 				"app.openshift.io/connects-to": "container-jfr-operator",
 			},
 		},
@@ -137,9 +136,6 @@ func NewDeploymentForCR(cr *rhjmcv1beta1.ContainerJFR, specs *ServiceSpecs, tls 
 					Labels: map[string]string{
 						"app":  cr.Name,
 						"kind": "containerjfr",
-					},
-					Annotations: map[string]string{
-						"redhat.com/containerJfrUrl": specs.CoreURL.String(),
 					},
 				},
 				Spec: *NewPodForCR(cr, specs, tls),

--- a/controllers/containerjfr_controller.go
+++ b/controllers/containerjfr_controller.go
@@ -259,7 +259,7 @@ func (r *ContainerJFRReconciler) Reconcile(ctx context.Context, request ctrl.Req
 		return reconcile.Result{}, err
 	}
 
-	instance.Status.DashboardURL = serviceSpecs.CoreURL.String()
+	instance.Status.ApplicationURL = serviceSpecs.CoreURL.String()
 	r.Client.Status().Update(context.Background(), instance)
 
 	// Check that secrets mounted in /truststore coincide with CRD

--- a/controllers/containerjfr_controller.go
+++ b/controllers/containerjfr_controller.go
@@ -260,7 +260,10 @@ func (r *ContainerJFRReconciler) Reconcile(ctx context.Context, request ctrl.Req
 	}
 
 	instance.Status.ApplicationURL = serviceSpecs.CoreURL.String()
-	r.Client.Status().Update(context.Background(), instance)
+	err = r.Client.Status().Update(context.Background(), instance)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
 
 	// Check that secrets mounted in /truststore coincide with CRD
 	err = r.Client.Get(context.Background(), types.NamespacedName{Name: deployment.Name, Namespace: deployment.Namespace}, deployment)

--- a/controllers/containerjfr_controller.go
+++ b/controllers/containerjfr_controller.go
@@ -259,6 +259,9 @@ func (r *ContainerJFRReconciler) Reconcile(ctx context.Context, request ctrl.Req
 		return reconcile.Result{}, err
 	}
 
+	instance.Status.DashboardURL = serviceSpecs.CoreURL.String()
+	r.Client.Status().Update(context.Background(), instance)
+
 	// Check that secrets mounted in /truststore coincide with CRD
 	err = r.Client.Get(context.Background(), types.NamespacedName{Name: deployment.Name, Namespace: deployment.Namespace}, deployment)
 	if err == nil {

--- a/controllers/containerjfr_controller_test.go
+++ b/controllers/containerjfr_controller_test.go
@@ -141,6 +141,9 @@ var _ = Describe("ContainerjfrController", func() {
 			It("should create exporter service and set owner", func() {
 				expectExporterService(client, controller, false, tls)
 			})
+			It("should set DashboardURL in CR Status", func() {
+				expectStatusDashboardURL(client, controller, false, tls)
+			})
 			It("should create command channel service and set owner", func() {
 				expectCommandChannel(client, controller, false, tls)
 			})
@@ -168,6 +171,9 @@ var _ = Describe("ContainerjfrController", func() {
 			})
 			It("should create exporter service and set owner", func() {
 				expectExporterService(client, controller, true, tls)
+			})
+			It("should set DashboardURL in CR Status", func() {
+				expectStatusDashboardURL(client, controller, true, tls)
 			})
 			It("should create command channel service and set owner", func() {
 				expectCommandChannel(client, controller, true, tls)
@@ -635,6 +641,18 @@ func expectExporterService(client ctrlclient.Client, controller *controllers.Con
 	Expect(service.Spec.Ports).To(Equal(expectedService.Spec.Ports))
 }
 
+func expectStatusDashboardURL(client ctrlclient.Client, controller *controllers.ContainerJFRReconciler, minimal bool, tls bool) {
+	instance := &rhjmcv1beta1.ContainerJFR{}
+	err := client.Get(context.Background(), types.NamespacedName{Name: "containerjfr", Namespace: "default"}, instance)
+
+	reconcileContainerJFRFully(client, controller, minimal, tls)
+
+	err = client.Get(context.Background(), types.NamespacedName{Name: "containerjfr", Namespace: "default"}, instance)
+	Expect(err).ToNot(HaveOccurred())
+
+	Expect(instance.Status.DashboardURL).To(Equal("https://containerjfr.example.com"))
+}
+
 func expectCommandChannel(client ctrlclient.Client, controller *controllers.ContainerJFRReconciler, minimal bool, tls bool) {
 	service := &corev1.Service{}
 	err := client.Get(context.Background(), types.NamespacedName{Name: "containerjfr-command", Namespace: "default"}, service)
@@ -705,7 +723,6 @@ func checkDeployment(client ctrlclient.Client, minimal bool, tls bool) {
 	Expect(deployment.Name).To(Equal("containerjfr"))
 	Expect(deployment.Namespace).To(Equal("default"))
 	Expect(deployment.Annotations).To(Equal(map[string]string{
-		"redhat.com/containerJfrUrl":   "https://containerjfr.example.com",
 		"app.openshift.io/connects-to": "container-jfr-operator",
 	}))
 	Expect(deployment.Labels).To(Equal(map[string]string{
@@ -720,9 +737,6 @@ func checkDeployment(client ctrlclient.Client, minimal bool, tls bool) {
 	template := deployment.Spec.Template
 	Expect(template.Name).To(Equal("containerjfr"))
 	Expect(template.Namespace).To(Equal("default"))
-	Expect(template.Annotations).To(Equal(map[string]string{
-		"redhat.com/containerJfrUrl": "https://containerjfr.example.com",
-	}))
 	Expect(template.Labels).To(Equal(map[string]string{
 		"app":  "containerjfr",
 		"kind": "containerjfr",

--- a/controllers/containerjfr_controller_test.go
+++ b/controllers/containerjfr_controller_test.go
@@ -141,8 +141,8 @@ var _ = Describe("ContainerjfrController", func() {
 			It("should create exporter service and set owner", func() {
 				expectExporterService(client, controller, false, tls)
 			})
-			It("should set DashboardURL in CR Status", func() {
-				expectStatusDashboardURL(client, controller, false, tls)
+			It("should set ApplicationURL in CR Status", func() {
+				expectStatusApplicationURL(client, controller, false, tls)
 			})
 			It("should create command channel service and set owner", func() {
 				expectCommandChannel(client, controller, false, tls)
@@ -172,8 +172,8 @@ var _ = Describe("ContainerjfrController", func() {
 			It("should create exporter service and set owner", func() {
 				expectExporterService(client, controller, true, tls)
 			})
-			It("should set DashboardURL in CR Status", func() {
-				expectStatusDashboardURL(client, controller, true, tls)
+			It("should set ApplicationURL in CR Status", func() {
+				expectStatusApplicationURL(client, controller, true, tls)
 			})
 			It("should create command channel service and set owner", func() {
 				expectCommandChannel(client, controller, true, tls)
@@ -641,7 +641,7 @@ func expectExporterService(client ctrlclient.Client, controller *controllers.Con
 	Expect(service.Spec.Ports).To(Equal(expectedService.Spec.Ports))
 }
 
-func expectStatusDashboardURL(client ctrlclient.Client, controller *controllers.ContainerJFRReconciler, minimal bool, tls bool) {
+func expectStatusApplicationURL(client ctrlclient.Client, controller *controllers.ContainerJFRReconciler, minimal bool, tls bool) {
 	instance := &rhjmcv1beta1.ContainerJFR{}
 	err := client.Get(context.Background(), types.NamespacedName{Name: "containerjfr", Namespace: "default"}, instance)
 
@@ -650,7 +650,7 @@ func expectStatusDashboardURL(client ctrlclient.Client, controller *controllers.
 	err = client.Get(context.Background(), types.NamespacedName{Name: "containerjfr", Namespace: "default"}, instance)
 	Expect(err).ToNot(HaveOccurred())
 
-	Expect(instance.Status.DashboardURL).To(Equal("https://containerjfr.example.com"))
+	Expect(instance.Status.ApplicationURL).To(Equal("https://containerjfr.example.com"))
 }
 
 func expectCommandChannel(client ctrlclient.Client, controller *controllers.ContainerJFRReconciler, minimal bool, tls bool) {


### PR DESCRIPTION
This removes the `containerJfrUrl` annotation from the `Deployment` and adds a `dashboardUrl`
field to the `ContainerJFRStatus`, which is set once the controller has
set up the corresponding Service/Route.

Fixes #150

```
$ oc get -o yaml containerjfr
apiVersion: v1
items:
- apiVersion: rhjmc.redhat.com/v1beta1
  kind: ContainerJFR
  metadata:
    creationTimestamp: "2021-04-07T14:34:21Z"
    finalizers:
    - rhjmc.redhat.com/containerjfr.finalizer
    generation: 2
    managedFields:
    - apiVersion: rhjmc.redhat.com/v1beta1
      fieldsType: FieldsV1
      fieldsV1:
        f:spec:
          .: {}
          f:minimal: {}
          f:storageOptions:
            .: {}
            f:pvc:
              .: {}
              f:spec: {}
      manager: oc
      operation: Update
      time: "2021-04-07T14:34:21Z"
    - apiVersion: rhjmc.redhat.com/v1beta1
      fieldsType: FieldsV1
      fieldsV1:
        f:metadata:
          f:finalizers: {}
        f:spec:
          f:storageOptions:
            f:pvc:
              f:spec:
                f:resources: {}
        f:status:
          .: {}
          f:dashboardUrl: {}
      manager: manager
      operation: Update
      time: "2021-04-07T14:34:24Z"
    name: containerjfr-sample
    namespace: myproject
    resourceVersion: "248223"
    selfLink: /apis/rhjmc.redhat.com/v1beta1/namespaces/myproject/containerjfrs/containerjfr-sample
    uid: 353e1363-3519-4626-ba55-aa5aa5875a84
  spec:
    minimal: false
    storageOptions:
      pvc:
        spec:
          resources: {}
  status:
    dashboardUrl: https://containerjfr-sample-myproject.apps-crc.testing
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```

![Screenshot_2021-04-07 Red Hat OpenShift Container Platform](https://user-images.githubusercontent.com/3787464/113885623-81578680-97af-11eb-8861-7d8c7d167bcc.png)
