### PR TITLE
Add startup probe to core container

### DIFF
--- a/controllers/containerjfr_controller_test.go
+++ b/controllers/containerjfr_controller_test.go
@@ -766,6 +766,7 @@ func checkCoreContainer(container *corev1.Container, minimal bool, tls bool) {
 	Expect(container.EnvFrom).To(ConsistOf(test.NewCoreEnvFromSource(tls)))
 	Expect(container.VolumeMounts).To(ConsistOf(test.NewCoreVolumeMounts(tls)))
 	Expect(container.LivenessProbe).To(Equal(test.NewCoreLivenessProbe(tls)))
+	Expect(container.StartupProbe).To(Equal(test.NewCoreStartupProbe(tls)))
 }
 
 func checkGrafanaContainer(container *corev1.Container, tls bool) {

--- a/test/resources.go
+++ b/test/resources.go
@@ -893,17 +893,28 @@ func NewVolumeMountsWithSecrets() []corev1.VolumeMount {
 }
 
 func NewCoreLivenessProbe(tls bool) *corev1.Probe {
+	return &corev1.Probe{
+		Handler: newCoreProbeHandler(tls),
+	}
+}
+
+func NewCoreStartupProbe(tls bool) *corev1.Probe {
+	return &corev1.Probe{
+		Handler:          newCoreProbeHandler(tls),
+		FailureThreshold: 18,
+	}
+}
+
+func newCoreProbeHandler(tls bool) corev1.Handler {
 	protocol := corev1.URISchemeHTTPS
 	if !tls {
 		protocol = corev1.URISchemeHTTP
 	}
-	return &corev1.Probe{
-		Handler: corev1.Handler{
-			HTTPGet: &corev1.HTTPGetAction{
-				Port:   intstr.IntOrString{IntVal: 8181},
-				Path:   "/api/v1/clienturl",
-				Scheme: protocol,
-			},
+	return corev1.Handler{
+		HTTPGet: &corev1.HTTPGetAction{
+			Port:   intstr.IntOrString{IntVal: 8181},
+			Path:   "/api/v1/clienturl",
+			Scheme: protocol,
 		},
 	}
 }


### PR DESCRIPTION
I've noticed occasionally the liveness probe will fail on the core Container JFR container during startup. There's a relatively new Startup Probe feature that's designed to be more lenient for containers that are slower to start [1]. This PR adds a startup probe with a 3 minute threshold (18 * 10s period), if the probe succeeds within this period, the liveness probe will take over, otherwise the container will be killed.

[1] https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#when-should-you-use-a-startup-probe