### PR TITLE
Set up GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,28 @@
+name: CI build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '^1.15.8'
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - uses: jpkrohling/setup-operator-sdk@v1.1.0
+      with:
+        operator-sdk-version: v1.5.0
+    - run: make generate manifests manager test-envtest

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 # Current Operator version
 IMAGE_VERSION ?= 1.0.0-beta5
 BUNDLE_VERSION ?= $(IMAGE_VERSION)

--- a/controllers/recording_controller_test.go
+++ b/controllers/recording_controller_test.go
@@ -560,7 +560,9 @@ func (t *recordingTestInput) expectRecordingUpdated(desc *jfrclient.RecordingDes
 	Expect(obj.Status.State).ToNot(BeNil())
 	Expect(*obj.Status.State).To(Equal(rhjmcv1beta1.RecordingState(desc.State)))
 	// Converted to RFC3339 during serialization (sub-second precision lost)
-	Expect(obj.Status.StartTime).To(Equal(metav1.Unix(0, desc.StartTime*int64(time.Millisecond)).Rfc3339Copy()))
+	expectedTime := metav1.Unix(0, desc.StartTime*int64(time.Millisecond)).Rfc3339Copy()
+	Expect(obj.Status.State).ToNot(BeNil())
+	Expect(obj.Status.StartTime.Equal(&expectedTime)).To(BeTrue())
 	Expect(obj.Status.Duration).To(Equal(metav1.Duration{
 		Duration: time.Duration(desc.Duration) * time.Millisecond,
 	}))


### PR DESCRIPTION
This sets up GitHub Actions CI similar to what is now present in the main project and -core/-web.

The envtests currently fail. See https://github.com/andrewazores/container-jfr-operator/runs/2382208792?check_suite_focus=true for full detail. The first failure looks like this and the rest appear the same/similar:

```
setting up env vars
?   	github.com/rh-jmc-team/container-jfr-operator	[no test files]
?   	github.com/rh-jmc-team/container-jfr-operator/api/v1beta1	[no test files]
=== RUN   TestAPIs
Running Suite: Controller Suite
===============================
Random Seed: 1618846108
Will run 111 of 111 specs

{"level":"info","ts":1618846115.7619064,"msg":"Reconciling Recording","Request.Namespace":"default","Request.Name":"my-recording"}
{"level":"info","ts":1618846115.763062,"msg":"added label for recording","namespace":"default","name":"my-recording"}
{"level":"info","ts":1618846115.7759614,"msg":"creating new recording","name":"test-recording","duration":"30s","eventOptions":["jdk.socketRead:enabled=true","jdk.socketWrite:enabled=true"]}
{"level":"info","ts":1618846115.782488,"msg":"Looking for recordings for pod","pod":"test-pod","namespace":"default"}
{"level":"info","ts":1618846115.7828703,"msg":"Recording successfully updated","Request.Namespace":"default","Request.Name":"my-recording","Namespace":"default","Name":"my-recording"}
• Failure [0.024 seconds]
RecordingController
/home/runner/work/container-jfr-operator/container-jfr-operator/controllers/recording_controller_test.go:68
  reconciling a request
  /home/runner/work/container-jfr-operator/container-jfr-operator/controllers/recording_controller_test.go:105
    with a new recording
    /home/runner/work/container-jfr-operator/container-jfr-operator/controllers/recording_controller_test.go:106
      updates status with recording info [It]
      /home/runner/work/container-jfr-operator/container-jfr-operator/controllers/recording_controller_test.go:114

      Expected
          <v1.Time>: {
              Time: 2020-08-10T20:07:10Z,
          }
      to equal
          <v1.Time>: {
              Time: 2020-08-10T20:07:10Z,
          }

      /home/runner/work/container-jfr-operator/container-jfr-operator/controllers/recording_controller_test.go:563
```